### PR TITLE
fix: stabilize published docs and ui declaration props

### DIFF
--- a/.changeset/shaggy-cobras-clean.md
+++ b/.changeset/shaggy-cobras-clean.md
@@ -1,0 +1,6 @@
+---
+"@gentleduck/docs": patch
+"@gentleduck/registry-ui": patch
+---
+
+Fix declaration output for shared docs and registry UI components so consumer apps keep valid props during production typechecking.

--- a/packages/duck-docs/src/components/style-switcher.tsx
+++ b/packages/duck-docs/src/components/style-switcher.tsx
@@ -6,7 +6,14 @@ import { cn } from '@gentleduck/libs/cn'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gentleduck/registry-ui/select'
 import type * as React from 'react'
 
-export function StyleSwitcher({ className, ...props }: React.ComponentPropsWithoutRef<typeof SelectTrigger>) {
+/**
+ * Keep the public prop contract local and button-like. The docs app only needs
+ * standard trigger props such as `className` and `disabled`, and this avoids
+ * brittle declaration inference across package boundaries.
+ */
+export interface StyleSwitcherProps extends React.ComponentPropsWithoutRef<'button'> {}
+
+export function StyleSwitcher({ className, ...props }: StyleSwitcherProps) {
   const [config, setConfig] = useConfig()
 
   return (

--- a/packages/registry-ui/src/button/button.constants.ts
+++ b/packages/registry-ui/src/button/button.constants.ts
@@ -1,6 +1,30 @@
 import { cva } from '@gentleduck/variants'
 
-export const buttonVariants = cva(
+type ButtonClassValue = string | number | boolean | Record<string, boolean | undefined> | ButtonClassValue[]
+
+export type ButtonBorder = 'default' | 'destructive' | 'primary' | 'secondary' | 'warning'
+export type ButtonSize = 'default' | 'icon' | 'icon-lg' | 'icon-sm' | 'lg' | 'sm'
+export type ButtonVariant =
+  | 'dashed'
+  | 'default'
+  | 'destructive'
+  | 'expand_icon'
+  | 'ghost'
+  | 'link'
+  | 'nothing'
+  | 'outline'
+  | 'secondary'
+  | 'warning'
+
+export interface ButtonVariantOptions {
+  border?: ButtonBorder | ButtonBorder[]
+  class?: ButtonClassValue
+  className?: ButtonClassValue
+  size?: ButtonSize | ButtonSize[]
+  variant?: ButtonVariant | ButtonVariant[]
+}
+
+export const buttonVariants: (props?: ButtonVariantOptions) => string = cva(
   "relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium text-sm outline-none transition-all focus-visible:border-ring focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 
   {

--- a/packages/registry-ui/src/select/select.tsx
+++ b/packages/registry-ui/src/select/select.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { cn } from '@gentleduck/libs/cn'
+import type { SelectTriggerProps as PrimitiveSelectTriggerProps } from '@gentleduck/primitives/select'
 import * as SelectPrimitive from '@gentleduck/primitives/select'
 import { Check, ChevronDown, ChevronUp } from 'lucide-react'
 import * as React from 'react'
@@ -14,24 +15,25 @@ SelectGroup.displayName = 'SelectGroup'
 const SelectValue = SelectPrimitive.Value
 SelectValue.displayName = 'SelectValue'
 
-const SelectTrigger = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Trigger
-    ref={ref}
-    data-slot="select-trigger"
-    className={cn(
-      'flex h-9 min-w-32 items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-placeholder:text-muted-foreground [&>span]:line-clamp-1',
-      className,
-    )}
-    {...props}>
-    {children}
-    <SelectPrimitive.Icon asChild>
-      <ChevronDown aria-hidden="true" className="size-4 opacity-50" />
-    </SelectPrimitive.Icon>
-  </SelectPrimitive.Trigger>
-))
+export interface SelectTriggerProps extends PrimitiveSelectTriggerProps {}
+
+const SelectTrigger = React.forwardRef<React.ComponentRef<typeof SelectPrimitive.Trigger>, SelectTriggerProps>(
+  ({ className, children, ...props }, ref) => (
+    <SelectPrimitive.Trigger
+      ref={ref}
+      data-slot="select-trigger"
+      className={cn(
+        'flex h-9 min-w-32 items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-placeholder:text-muted-foreground [&>span]:line-clamp-1',
+        className,
+      )}
+      {...props}>
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDown aria-hidden="true" className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  ),
+)
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
 
 const SelectScrollUpButton = React.forwardRef<


### PR DESCRIPTION
## Summary
- keep `StyleSwitcher` props local in `@gentleduck/docs` so published declarations stay valid for consumer apps
- export `SelectTriggerProps` explicitly from `@gentleduck/registry-ui/select`
- give `buttonVariants` an explicit local input contract so generated declarations stay syntactically valid

## Validation
- `bun run check-types` in `packages/registry-ui`
- `bun test` in `packages/registry-ui`
- `bun run check-types` in `packages/duck-docs`
- `bun test` in `packages/duck-docs`
- `bun run build` in `packages/duck-docs`
- `bun run build` in `apps/duck-ui-docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type declaration output for component packages to ensure properties are correctly validated during production typechecking in consuming applications.

* **Refactor**
  * Introduced explicit TypeScript type definitions and interfaces for button styling variants and select component properties to enhance type safety and improve developer experience with better IDE support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->