### PR TITLE
feat(calendar): #309 - Multi-month, time picker, and datetime picker

### DIFF
--- a/packages/duck-calendar/PLAN.md
+++ b/packages/duck-calendar/PLAN.md
@@ -1,71 +1,51 @@
-# duck-calendar: Accessibility Audit and ARIA Compliance
+# duck-calendar: Multi-month, Time Picker, DateTime Picker
 
-Issue #308. Ensure the calendar meets WCAG 2.1 AA and follows the WAI-ARIA APG date picker pattern.
+Issue #309. Extend the calendar engine with multi-month display, time selection, and combined datetime picking.
 
-> Depends on: #304 (adapter), #305 (core), #306 (hooks), #307 (compound components) — all complete.
+> Depends on: #304–#308 — all complete.
 
-## Changes Made
+## Feature 1: Multi-month
 
-### Announcer — removed portal
-- `AnnouncerPortal` no longer uses `createPortal` from `react-dom`
-- Renders inline `<div aria-live="polite">` inside the calendar tree
-- Eliminates `react-dom` peer dependency from `@gentleduck/calendar`
+- `buildMultiMonth(adapter, startMonth, count, config)` — builds N consecutive month grids
+- `useCalendar` accepts `numberOfMonths` config, returns `state.months[]` array
+- `state.weeks` preserved for backward compat (first month's weeks)
+- Navigation advances all months together
 
-### Day buttons — full aria-label
-- Each day button now has `aria-label="Saturday, March 14, 2026"` (localized)
-- Previously screen readers only heard the number "14"
+## Feature 2: Time Picker
 
-### data-disabled consistency
-- Changed from empty string `""` to `"true"` to match all other data attributes
+### Core (`src/time/`)
+- `TimeValue` — `{ hour, minute, second? }`
+- `TimeField` — `'hour' | 'minute' | 'second' | 'ampm'`
+- `HourCycle` — `'12' | '24'`
+- Pure functions: `clampTime`, `incrementField`, `parseTimeInput`, `isValidTime`
+- Formatting: `formatTimeField`, `getAmPm`, `to12Hour`, `to24Hour`
 
-### Grid — aria-roledescription
-- Grid has `aria-roledescription="calendar"` per WAI-ARIA APG recommendation
+### Hook (`src/react/use-time-picker/`)
+- `useTimePicker(config)` — controlled/uncontrolled time state
+- Keyboard: ArrowUp/Down increment/decrement, digit typing
+- `getFieldProps(field)` — spinbutton ARIA props
+- Focus management with roving tabindex between fields
 
-### Weekday headers — role="columnheader"
-- `<abbr>` elements have `role="columnheader"` per WAI-ARIA grid pattern
+### DateAdapter extensions
+- `getHours(date)`, `getMinutes(date)`, `getSeconds(date)`, `setTime(date, h, m, s?)`
 
-### Nav labels — localizable
-- `buildNavProps` accepts optional `prevLabel`/`nextLabel` for i18n
-- Defaults: "Go to previous month" / "Go to next month"
+## Feature 3: DateTime Picker
 
-## ARIA Compliance Summary
-
-| Element | role | aria-* | Notes |
-|---------|------|--------|-------|
-| Calendar root | `application` | `aria-label="Calendar"` | |
-| Grid container | `grid` | `aria-labelledby`, `aria-roledescription="calendar"` | |
-| Weekday headers | `columnheader` | `title` on `<abbr>` | |
-| Day cells | `gridcell` | `aria-label` (full date), `aria-selected`, `aria-disabled`, `aria-current="date"` | |
-| Nav wrapper | `navigation` | `aria-label="Calendar navigation"` | |
-| Nav buttons | button | `aria-label` (localizable) | |
-| Header | — | `aria-live="polite"`, `id` | |
-| Month buttons | `gridcell` | `aria-label`, `aria-current` | |
-| Year buttons | `gridcell` | `aria-label`, `aria-current` | |
-| Announcer | `status` | `aria-live="polite"`, `aria-atomic`, `aria-relevant` | |
-
-## Keyboard Navigation
-
-| Key | Action |
-|-----|--------|
-| ArrowLeft/Right | ±1 day |
-| ArrowUp/Down | ±7 days |
-| PageUp/PageDown | ±1 month |
-| Shift+PageUp/PageDown | ±1 year |
-| Home/End | Week start/end |
-| Enter/Space | Select focused date |
-| Escape | Dismiss |
-
-Focus auto-advances the displayed month when crossing boundaries.
-Roving tabIndex: focused date has `tabIndex=0`, all others `-1`.
+### Hook (`src/react/use-datetime/`)
+- `useDateTime(config)` — composes `useCalendar` + `useTimePicker`
+- Date selection preserves time, time change preserves date
+- Returns combined `TDate` value
 
 ## Checklist
 
-- [x] Remove announcer portal (render inline)
-- [x] Add aria-label to day buttons (full localized date)
-- [x] Fix data-disabled consistency
-- [x] Add aria-roledescription to grid
-- [x] Restore role="columnheader" on weekday headers
-- [x] Localizable nav labels
-- [ ] Axe-core automated tests
-- [x] Build passes
-- [x] All tests pass
+- [x] DateAdapter time methods + NativeAdapter impl
+- [x] Time core module (types, functions, formatting)
+- [x] Multi-month: `buildMultiMonth` + `useCalendar` update
+- [ ] useTimePicker hook
+- [ ] useDateTime hook
+- [ ] Time core tests
+- [ ] useTimePicker tests
+- [ ] useDateTime tests
+- [ ] Barrel exports
+- [ ] Build passes
+- [ ] All tests pass

--- a/packages/duck-calendar/src/adapter/adapter.types.ts
+++ b/packages/duck-calendar/src/adapter/adapter.types.ts
@@ -155,4 +155,23 @@ export interface DateAdapter<TDate> {
    *   Falls back to the runtime's default locale when omitted.
    */
   format(date: TDate, options: Intl.DateTimeFormatOptions, locale?: string): string
+
+  // -------------------------------------------------------------------------
+  // Time accessors (for datetime picker support)
+  // -------------------------------------------------------------------------
+
+  /** Extracts the hour (0–23). */
+  getHours(date: TDate): number
+
+  /** Extracts the minute (0–59). */
+  getMinutes(date: TDate): number
+
+  /** Extracts the second (0–59). */
+  getSeconds(date: TDate): number
+
+  /**
+   * Returns a new date with the time set to the given hour, minute, and optional second.
+   * The date (year/month/day) is preserved from the input.
+   */
+  setTime(date: TDate, hour: number, minute: number, second?: number): TDate
 }

--- a/packages/duck-calendar/src/adapter/native-adapter.ts
+++ b/packages/duck-calendar/src/adapter/native-adapter.ts
@@ -108,4 +108,20 @@ export class NativeAdapter implements DateAdapter<Date> {
   format(date: Date, options: Intl.DateTimeFormatOptions, locale?: string): string {
     return new Intl.DateTimeFormat(locale, options).format(date)
   }
+
+  getHours(date: Date): number {
+    return date.getHours()
+  }
+
+  getMinutes(date: Date): number {
+    return date.getMinutes()
+  }
+
+  getSeconds(date: Date): number {
+    return date.getSeconds()
+  }
+
+  setTime(date: Date, hour: number, minute: number, second?: number): Date {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate(), hour, minute, second ?? 0)
+  }
 }

--- a/packages/duck-calendar/src/grid/grid.ts
+++ b/packages/duck-calendar/src/grid/grid.ts
@@ -67,6 +67,24 @@ export function buildCalendarMonth<TDate>(
   }
 }
 
+/**
+ * Build grids for multiple consecutive months.
+ * Used when `numberOfMonths > 1` for multi-month calendar displays.
+ */
+export function buildMultiMonth<TDate>(
+  adapter: DateAdapter<TDate>,
+  startMonth: TDate,
+  count: number,
+  config: Pick<CalendarConfig<TDate, any>, 'showOutsideDays' | 'fixedWeeks' | 'locale'>,
+): CalendarMonth<TDate>[] {
+  const months: CalendarMonth<TDate>[] = []
+  for (let i = 0; i < count; i++) {
+    const monthDate = i === 0 ? startMonth : adapter.addMonths(startMonth, i)
+    months.push(buildCalendarMonth(adapter, monthDate, config))
+  }
+  return months
+}
+
 /** Build 12 month entries for the year picker view. */
 export function buildCalendarYear<TDate>(adapter: DateAdapter<TDate>, viewDate: TDate, locale?: string): YearEntry[] {
   const today = adapter.today()

--- a/packages/duck-calendar/src/grid/index.ts
+++ b/packages/duck-calendar/src/grid/index.ts
@@ -1,3 +1,3 @@
-export { buildCalendarMonth, buildCalendarYear, buildDecadeView } from './grid'
+export { buildCalendarMonth, buildCalendarYear, buildDecadeView, buildMultiMonth } from './grid'
 export { getLocalizedMonthNames, getLocalizedWeekdays, getWeekNumber } from './grid.libs'
 export type { CalendarDay, CalendarMonth, CalendarWeek, DecadeEntry, YearEntry } from './grid.types'

--- a/packages/duck-calendar/src/index.ts
+++ b/packages/duck-calendar/src/index.ts
@@ -7,6 +7,7 @@ export {
   buildCalendarMonth,
   buildCalendarYear,
   buildDecadeView,
+  buildMultiMonth,
   getLocalizedMonthNames,
   getLocalizedWeekdays,
   getWeekNumber,
@@ -25,11 +26,28 @@ export type {
   KeyboardConfig,
   KeyboardReturn,
   NavProps,
+  TimeFieldProps,
   UseCalendarConfig,
   UseCalendarReturn,
+  UseDateTimeConfig,
+  UseDateTimeReturn,
+  UseTimePickerConfig,
+  UseTimePickerReturn,
 } from './react'
 // React hooks (requires react peer dep)
-export { useAnnouncer, useCalendar, useKeyboard } from './react'
+export { useAnnouncer, useCalendar, useDateTime, useKeyboard, useTimePicker } from './react'
 export type { CalendarValue, DateRange, SelectionConstraints, SelectionMode } from './selection'
 // Selection
 export { applySelection, isDateDisabled, isInRange, selectDay } from './selection'
+// Time
+export type { HourCycle, TimeField, TimePickerConfig, TimeValue } from './time'
+export {
+  clampTime,
+  formatTimeField,
+  getAmPm,
+  incrementField,
+  isValidTime,
+  parseTimeInput,
+  to12Hour,
+  to24Hour,
+} from './time'

--- a/packages/duck-calendar/src/index.types.ts
+++ b/packages/duck-calendar/src/index.types.ts
@@ -37,6 +37,8 @@ export interface CalendarConfig<TDate, M extends SelectionMode = 'single'> {
   /** Called when the displayed month changes. */
   onMonthChange?: (month: TDate) => void
 
+  /** How many months to show side by side. Default `1`. */
+  numberOfMonths?: number
   /** Show days from previous/next month to fill the grid. Default `true`. */
   showOutsideDays?: boolean
   /** Always show 6 weeks so the grid height doesn't jump. Default `false`. */

--- a/packages/duck-calendar/src/react/index.ts
+++ b/packages/duck-calendar/src/react/index.ts
@@ -15,5 +15,9 @@ export type {
   UseCalendarReturn,
 } from './use-calendar'
 export { useCalendar } from './use-calendar'
+export type { UseDateTimeConfig, UseDateTimeReturn } from './use-datetime'
+export { useDateTime } from './use-datetime'
 export type { KeyboardConfig, KeyboardReturn } from './use-keyboard'
 export { useKeyboard } from './use-keyboard'
+export type { TimeFieldProps, UseTimePickerConfig, UseTimePickerReturn } from './use-time-picker'
+export { useTimePicker } from './use-time-picker'

--- a/packages/duck-calendar/src/react/use-calendar/use-calendar.ts
+++ b/packages/duck-calendar/src/react/use-calendar/use-calendar.ts
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
-import { buildCalendarMonth, type CalendarDay, getLocalizedWeekdays } from '../../grid'
+import {
+  buildCalendarMonth,
+  buildMultiMonth,
+  type CalendarDay,
+  type CalendarMonth,
+  getLocalizedWeekdays,
+} from '../../grid'
 import type { ViewMode } from '../../index.types'
 import { canNavigate, navigate } from '../../navigation'
 import type { CalendarValue, DateRange, SelectionConstraints, SelectionMode } from '../../selection'
@@ -12,33 +18,9 @@ import {
   useAnnouncer,
 } from '../use-announcer'
 import { useKeyboard } from '../use-keyboard'
+import { useControllableState } from '../utils/use-controllable-state'
 import { buildDayProps, buildGridProps, buildHeaderProps, buildNavProps } from './use-calendar.libs'
 import type { UseCalendarConfig, UseCalendarReturn } from './use-calendar.types'
-
-// ---------------------------------------------------------------------------
-// useControllableState — tiny controlled/uncontrolled helper
-// ---------------------------------------------------------------------------
-
-function useControllableState<T>(
-  controlled: T | undefined,
-  uncontrolled: T,
-  onChange?: (val: T) => void,
-): [T, (val: T) => void] {
-  const [internal, setInternal] = useState<T>(uncontrolled)
-  const isControlled = controlled !== undefined
-
-  const value = isControlled ? controlled : internal
-
-  const setValue = useCallback(
-    (next: T) => {
-      if (!isControlled) setInternal(next)
-      onChange?.(next)
-    },
-    [isControlled, onChange],
-  )
-
-  return [value, setValue]
-}
 
 // ---------------------------------------------------------------------------
 // useCalendar
@@ -57,6 +39,7 @@ export function useCalendar<TDate, M extends SelectionMode = 'single'>(
     defaultSelected,
     onSelect,
     onMonthChange,
+    numberOfMonths = 1,
     showOutsideDays = true,
     fixedWeeks = false,
     disabled,
@@ -108,10 +91,21 @@ export function useCalendar<TDate, M extends SelectionMode = 'single'>(
   // -------------------------------------------------------------------------
   // Grid — rebuild when month, value, or constraints change
   // -------------------------------------------------------------------------
-  const weeks = useMemo(() => {
-    const raw = buildCalendarMonth(adapter, month, { showOutsideDays, fixedWeeks, locale })
-    return applySelection(raw.weeks, adapter, mode, value, constraints)
-  }, [adapter, month, mode, value, constraints, showOutsideDays, fixedWeeks, locale])
+  const months: CalendarMonth<TDate>[] = useMemo(() => {
+    const gridConfig = { showOutsideDays, fixedWeeks, locale }
+    const rawMonths =
+      numberOfMonths <= 1
+        ? [buildCalendarMonth(adapter, month, gridConfig)]
+        : buildMultiMonth(adapter, month, numberOfMonths, gridConfig)
+
+    return rawMonths.map((m) => ({
+      ...m,
+      weeks: applySelection(m.weeks, adapter, mode, value, constraints),
+    }))
+  }, [adapter, month, mode, value, constraints, showOutsideDays, fixedWeeks, locale, numberOfMonths])
+
+  // First month's weeks for backward compat
+  const weeks = months[0]?.weeks ?? []
 
   // -------------------------------------------------------------------------
   // Weekday headers
@@ -244,7 +238,7 @@ export function useCalendar<TDate, M extends SelectionMode = 'single'>(
   // Return
   // -------------------------------------------------------------------------
   return {
-    state: { month, value, focusedDate, viewMode, weeks, weekdays, canGoNext, canGoPrevious },
+    state: { month, value, focusedDate, viewMode, weeks, months, weekdays, canGoNext, canGoPrevious },
     actions: {
       setMonth,
       setViewMode,

--- a/packages/duck-calendar/src/react/use-calendar/use-calendar.types.ts
+++ b/packages/duck-calendar/src/react/use-calendar/use-calendar.types.ts
@@ -1,4 +1,4 @@
-import type { CalendarDay, CalendarWeek } from '../../grid'
+import type { CalendarDay, CalendarMonth, CalendarWeek } from '../../grid'
 import type { CalendarConfig, ViewMode } from '../../index.types'
 import type { CalendarValue, SelectionMode } from '../../selection'
 import type { AnnouncerReturn } from '../use-announcer'
@@ -57,8 +57,10 @@ export interface UseCalendarReturn<TDate, M extends SelectionMode> {
     focusedDate: TDate
     /** Whether we're showing the day grid, month picker, or year picker. */
     viewMode: ViewMode
-    /** Decorated weeks ready to render. */
+    /** Decorated weeks for the first (or only) month. */
     weeks: CalendarWeek<TDate>[]
+    /** All month grids when numberOfMonths > 1. */
+    months: CalendarMonth<TDate>[]
     /** Localised weekday header labels (7 items). */
     weekdays: string[]
     /** Whether forward navigation is possible (respects toDate). */

--- a/packages/duck-calendar/src/react/use-datetime/__test__/use-datetime.test.tsx
+++ b/packages/duck-calendar/src/react/use-datetime/__test__/use-datetime.test.tsx
@@ -1,0 +1,201 @@
+import { act, renderHook } from '@testing-library/react'
+import { NativeAdapter } from '../../../adapter'
+import { useDateTime } from '../use-datetime'
+
+const adapter = new NativeAdapter()
+const march15_1430 = new Date(2026, 2, 15, 14, 30, 0)
+
+describe('useDateTime', () => {
+  // ---------------------------------------------------------------------------
+  // Initial value
+  // ---------------------------------------------------------------------------
+  describe('initial value', () => {
+    it('extracts date and time from defaultValue', () => {
+      const { result } = renderHook(() =>
+        useDateTime({
+          adapter,
+          defaultValue: march15_1430,
+        }),
+      )
+
+      expect(result.current.state.value).not.toBeNull()
+      const val = result.current.state.value!
+      expect(val.getFullYear()).toBe(2026)
+      expect(val.getMonth()).toBe(2)
+      expect(val.getDate()).toBe(15)
+      expect(val.getHours()).toBe(14)
+      expect(val.getMinutes()).toBe(30)
+      expect(val.getSeconds()).toBe(0)
+    })
+
+    it('value is null when no defaultValue provided', () => {
+      const { result } = renderHook(() => useDateTime({ adapter }))
+
+      expect(result.current.state.value).toBeNull()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Selecting a date preserves the time
+  // ---------------------------------------------------------------------------
+  describe('date selection preserves time', () => {
+    it('selecting a new date keeps the existing time', () => {
+      const { result } = renderHook(() =>
+        useDateTime({
+          adapter,
+          defaultValue: march15_1430,
+          defaultMonth: new Date(2026, 2, 1),
+        }),
+      )
+
+      const march20 = new Date(2026, 2, 20)
+      act(() => {
+        result.current.calendar.actions.selectDate(march20)
+      })
+
+      const val = result.current.state.value!
+      expect(val.getDate()).toBe(20)
+      expect(val.getHours()).toBe(14)
+      expect(val.getMinutes()).toBe(30)
+      expect(val.getSeconds()).toBe(0)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Changing time preserves the date
+  // ---------------------------------------------------------------------------
+  describe('time change preserves date', () => {
+    it('changing time keeps the existing date', () => {
+      const { result } = renderHook(() =>
+        useDateTime({
+          adapter,
+          defaultValue: march15_1430,
+        }),
+      )
+
+      act(() => {
+        result.current.timePicker.actions.setValue({ hour: 9, minute: 15, second: 45 })
+      })
+
+      const val = result.current.state.value!
+      expect(val.getFullYear()).toBe(2026)
+      expect(val.getMonth()).toBe(2)
+      expect(val.getDate()).toBe(15)
+      expect(val.getHours()).toBe(9)
+      expect(val.getMinutes()).toBe(15)
+      expect(val.getSeconds()).toBe(45)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Controlled value follows prop
+  // ---------------------------------------------------------------------------
+  describe('controlled value', () => {
+    it('follows the controlled value prop', () => {
+      const { result, rerender } = renderHook(
+        ({ value }) =>
+          useDateTime({
+            adapter,
+            value,
+          }),
+        { initialProps: { value: march15_1430 } },
+      )
+
+      expect(result.current.state.value!.getHours()).toBe(14)
+
+      const newValue = new Date(2026, 5, 10, 8, 0, 0)
+      rerender({ value: newValue })
+
+      expect(result.current.state.value!.getMonth()).toBe(5)
+      expect(result.current.state.value!.getDate()).toBe(10)
+      expect(result.current.state.value!.getHours()).toBe(8)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // onChange fires with combined datetime
+  // ---------------------------------------------------------------------------
+  describe('onChange', () => {
+    it('fires with combined datetime when date is selected', () => {
+      const onChange = vi.fn()
+      const { result } = renderHook(() =>
+        useDateTime({
+          adapter,
+          defaultValue: march15_1430,
+          defaultMonth: new Date(2026, 2, 1),
+          onChange,
+        }),
+      )
+
+      const march22 = new Date(2026, 2, 22)
+      act(() => {
+        result.current.calendar.actions.selectDate(march22)
+      })
+
+      expect(onChange).toHaveBeenCalledOnce()
+      const received = onChange.mock.calls[0][0] as Date
+      expect(received.getDate()).toBe(22)
+      expect(received.getHours()).toBe(14)
+      expect(received.getMinutes()).toBe(30)
+    })
+
+    it('fires with combined datetime when time changes', () => {
+      const onChange = vi.fn()
+      const { result } = renderHook(() =>
+        useDateTime({
+          adapter,
+          defaultValue: march15_1430,
+          onChange,
+        }),
+      )
+
+      act(() => {
+        result.current.timePicker.actions.setValue({ hour: 18, minute: 0, second: 0 })
+      })
+
+      expect(onChange).toHaveBeenCalled()
+      const received = onChange.mock.calls[0][0] as Date
+      expect(received.getDate()).toBe(15)
+      expect(received.getHours()).toBe(18)
+      expect(received.getMinutes()).toBe(0)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Sub-returns are accessible
+  // ---------------------------------------------------------------------------
+  describe('sub-returns', () => {
+    it('calendar sub-return is accessible with expected shape', () => {
+      const { result } = renderHook(() =>
+        useDateTime({
+          adapter,
+          defaultValue: march15_1430,
+          defaultMonth: new Date(2026, 2, 1),
+        }),
+      )
+
+      expect(result.current.calendar.state).toBeDefined()
+      expect(result.current.calendar.actions).toBeDefined()
+      expect(typeof result.current.calendar.getDayProps).toBe('function')
+      expect(typeof result.current.calendar.getGridProps).toBe('function')
+      expect(typeof result.current.calendar.getNavProps).toBe('function')
+      expect(typeof result.current.calendar.getHeaderProps).toBe('function')
+    })
+
+    it('timePicker sub-return is accessible with expected shape', () => {
+      const { result } = renderHook(() =>
+        useDateTime({
+          adapter,
+          defaultValue: march15_1430,
+        }),
+      )
+
+      expect(result.current.timePicker.state).toBeDefined()
+      expect(result.current.timePicker.actions).toBeDefined()
+      expect(typeof result.current.timePicker.getFieldProps).toBe('function')
+      expect(result.current.timePicker.state.value).toBeDefined()
+      expect(typeof result.current.timePicker.state.value.hour).toBe('number')
+      expect(typeof result.current.timePicker.state.value.minute).toBe('number')
+    })
+  })
+})

--- a/packages/duck-calendar/src/react/use-datetime/index.ts
+++ b/packages/duck-calendar/src/react/use-datetime/index.ts
@@ -1,0 +1,2 @@
+export { useDateTime } from './use-datetime'
+export type { UseDateTimeConfig, UseDateTimeReturn } from './use-datetime.types'

--- a/packages/duck-calendar/src/react/use-datetime/use-datetime.ts
+++ b/packages/duck-calendar/src/react/use-datetime/use-datetime.ts
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { CalendarValue } from '../../selection'
+import type { TimeValue } from '../../time'
+import { useCalendar } from '../use-calendar'
+import { useTimePicker } from '../use-time-picker'
+import type { UseDateTimeConfig, UseDateTimeReturn } from './use-datetime.types'
+
+/**
+ * Composes `useCalendar` (single mode) and `useTimePicker` into a unified
+ * datetime picker hook. Selecting a date preserves the current time, and
+ * changing the time preserves the current date.
+ */
+export function useDateTime<TDate>(config: UseDateTimeConfig<TDate>): UseDateTimeReturn<TDate> {
+  const {
+    adapter,
+    locale,
+    value: controlledValue,
+    defaultValue,
+    onChange,
+    hourCycle,
+    showSeconds = false,
+    month,
+    defaultMonth,
+    onMonthChange,
+    disabled,
+    fromDate,
+    toDate,
+    onDismiss,
+  } = config
+
+  // ---------------------------------------------------------------------------
+  // Internal state — tracks the combined datetime
+  // ---------------------------------------------------------------------------
+  const isControlled = controlledValue !== undefined
+  const [internalValue, setInternalValue] = useState<TDate | null>(defaultValue ?? null)
+
+  const currentValue = isControlled ? controlledValue : internalValue
+
+  const setDateTime = useCallback(
+    (next: TDate) => {
+      if (!isControlled) setInternalValue(next)
+      onChange?.(next)
+    },
+    [isControlled, onChange],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Extract time from the current value (memoized to avoid new objects each render)
+  // ---------------------------------------------------------------------------
+  const extractTime = useCallback(
+    (date: TDate | null): TimeValue => {
+      if (date == null) return { hour: 0, minute: 0, second: 0 }
+      return {
+        hour: adapter.getHours(date),
+        minute: adapter.getMinutes(date),
+        second: adapter.getSeconds(date),
+      }
+    },
+    [adapter],
+  )
+
+  const timeValue = useMemo(() => extractTime(currentValue), [currentValue, extractTime])
+
+  // Keep a ref of the latest time so calendar selection can read it synchronously
+  const timeRef = useRef<TimeValue>(timeValue)
+
+  // Sync timeRef when the controlled value changes externally
+  useEffect(() => {
+    timeRef.current = timeValue
+  }, [timeValue])
+
+  // ---------------------------------------------------------------------------
+  // useCalendar — single mode
+  // ---------------------------------------------------------------------------
+  const calendar = useCalendar<TDate, 'single'>({
+    adapter,
+    mode: 'single',
+    locale,
+    month,
+    defaultMonth,
+    onMonthChange,
+    disabled,
+    fromDate,
+    toDate,
+    onDismiss,
+    selected: currentValue ?? undefined,
+    onSelect: (selected: CalendarValue<TDate, 'single'>) => {
+      if (selected == null) return
+      const date = selected as TDate
+      const t = timeRef.current
+      const merged = adapter.setTime(date, t.hour, t.minute, t.second)
+      setDateTime(merged)
+    },
+  })
+
+  // ---------------------------------------------------------------------------
+  // useTimePicker
+  // ---------------------------------------------------------------------------
+  const timePicker = useTimePicker({
+    value: timeValue,
+    hourCycle,
+    showSeconds,
+    onChange: (newTime: TimeValue) => {
+      timeRef.current = newTime
+      if (currentValue != null) {
+        const merged = adapter.setTime(currentValue, newTime.hour, newTime.minute, newTime.second ?? 0)
+        setDateTime(merged)
+      }
+    },
+  })
+
+  // ---------------------------------------------------------------------------
+  // Return
+  // ---------------------------------------------------------------------------
+  return {
+    calendar,
+    timePicker,
+    state: {
+      value: currentValue,
+    },
+    actions: {
+      setValue: setDateTime,
+    },
+  }
+}

--- a/packages/duck-calendar/src/react/use-datetime/use-datetime.types.ts
+++ b/packages/duck-calendar/src/react/use-datetime/use-datetime.types.ts
@@ -1,0 +1,34 @@
+import type { DateAdapter } from '../../adapter'
+import type { CalendarLocaleConfig } from '../../index.types'
+import type { HourCycle } from '../../time'
+import type { UseCalendarReturn } from '../use-calendar/use-calendar.types'
+import type { UseTimePickerReturn } from '../use-time-picker/use-time-picker.types'
+
+export interface UseDateTimeConfig<TDate> {
+  adapter: DateAdapter<TDate>
+  locale?: CalendarLocaleConfig
+  value?: TDate
+  defaultValue?: TDate
+  onChange?: (value: TDate) => void
+  hourCycle?: HourCycle
+  showSeconds?: boolean
+  // Calendar-specific
+  month?: TDate
+  defaultMonth?: TDate
+  onMonthChange?: (month: TDate) => void
+  disabled?: TDate[] | ((date: TDate) => boolean)
+  fromDate?: TDate
+  toDate?: TDate
+  onDismiss?: () => void
+}
+
+export interface UseDateTimeReturn<TDate> {
+  calendar: UseCalendarReturn<TDate, 'single'>
+  timePicker: UseTimePickerReturn
+  state: {
+    value: TDate | null
+  }
+  actions: {
+    setValue: (value: TDate) => void
+  }
+}

--- a/packages/duck-calendar/src/react/use-time-picker/__test__/use-time-picker.test.tsx
+++ b/packages/duck-calendar/src/react/use-time-picker/__test__/use-time-picker.test.tsx
@@ -1,0 +1,256 @@
+import { act, renderHook } from '@testing-library/react'
+import { useTimePicker } from '../use-time-picker'
+
+describe('useTimePicker', () => {
+  // ---------------------------------------------------------------------------
+  // Default value
+  // ---------------------------------------------------------------------------
+  it('default value is { hour: 0, minute: 0 }', () => {
+    const { result } = renderHook(() => useTimePicker())
+
+    expect(result.current.state.value).toEqual({ hour: 0, minute: 0 })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Controlled value
+  // ---------------------------------------------------------------------------
+  it('controlled value follows prop', () => {
+    const controlled = { hour: 14, minute: 30 }
+    const { result } = renderHook(() => useTimePicker({ value: controlled }))
+
+    expect(result.current.state.value).toEqual({ hour: 14, minute: 30 })
+  })
+
+  it('controlled value updates when prop changes', () => {
+    let value = { hour: 14, minute: 30 }
+    const { result, rerender } = renderHook(() => useTimePicker({ value }))
+
+    expect(result.current.state.value.hour).toBe(14)
+
+    value = { hour: 9, minute: 15 }
+    rerender()
+
+    expect(result.current.state.value).toEqual({ hour: 9, minute: 15 })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Increment / Decrement
+  // ---------------------------------------------------------------------------
+  it('increment("hour") advances by 1', () => {
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 10, minute: 0 } }))
+
+    act(() => {
+      result.current.actions.increment('hour')
+    })
+
+    expect(result.current.state.value.hour).toBe(11)
+  })
+
+  it('decrement("minute") decreases by 1', () => {
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 0, minute: 30 } }))
+
+    act(() => {
+      result.current.actions.decrement('minute')
+    })
+
+    expect(result.current.state.value.minute).toBe(29)
+  })
+
+  it('hour wraps: 23 + 1 = 0', () => {
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 23, minute: 0 } }))
+
+    act(() => {
+      result.current.actions.increment('hour')
+    })
+
+    expect(result.current.state.value.hour).toBe(0)
+  })
+
+  it('minute wraps: 0 - 1 = 59', () => {
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 0, minute: 0 } }))
+
+    act(() => {
+      result.current.actions.decrement('minute')
+    })
+
+    expect(result.current.state.value.minute).toBe(59)
+  })
+
+  // ---------------------------------------------------------------------------
+  // AM/PM toggle
+  // ---------------------------------------------------------------------------
+  it('toggleAmPm flips AM to PM', () => {
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 9, minute: 0 }, hourCycle: '12' }))
+
+    expect(result.current.state.displayAmPm).toBe('AM')
+
+    act(() => {
+      result.current.actions.toggleAmPm()
+    })
+
+    expect(result.current.state.displayAmPm).toBe('PM')
+    expect(result.current.state.value.hour).toBe(21)
+  })
+
+  it('toggleAmPm flips PM to AM', () => {
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 21, minute: 0 }, hourCycle: '12' }))
+
+    expect(result.current.state.displayAmPm).toBe('PM')
+
+    act(() => {
+      result.current.actions.toggleAmPm()
+    })
+
+    expect(result.current.state.displayAmPm).toBe('AM')
+    expect(result.current.state.value.hour).toBe(9)
+  })
+
+  // ---------------------------------------------------------------------------
+  // 12-hour display
+  // ---------------------------------------------------------------------------
+  it('12h display: hour 0 shows 12', () => {
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 0, minute: 0 }, hourCycle: '12' }))
+
+    expect(result.current.state.displayHour).toBe(12)
+    expect(result.current.state.displayAmPm).toBe('AM')
+  })
+
+  it('12h display: hour 13 shows 1', () => {
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 13, minute: 0 }, hourCycle: '12' }))
+
+    expect(result.current.state.displayHour).toBe(1)
+    expect(result.current.state.displayAmPm).toBe('PM')
+  })
+
+  it('24h display: hour 13 shows 13', () => {
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 13, minute: 0 }, hourCycle: '24' }))
+
+    expect(result.current.state.displayHour).toBe(13)
+  })
+
+  // ---------------------------------------------------------------------------
+  // getFieldProps
+  // ---------------------------------------------------------------------------
+  describe('getFieldProps', () => {
+    it('hour returns correct ARIA attrs', () => {
+      const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 14, minute: 30 }, hourCycle: '24' }))
+
+      const props = result.current.getFieldProps('hour')
+
+      expect(props.role).toBe('spinbutton')
+      expect(props['aria-label']).toBe('Hour')
+      expect(props['aria-valuemin']).toBe(0)
+      expect(props['aria-valuemax']).toBe(23)
+      expect(props['aria-valuenow']).toBe(14)
+      expect(props['aria-valuetext']).toBe('14')
+      expect(props['data-slot']).toBe('time-picker-field')
+    })
+
+    it('hour in 12h mode returns correct range', () => {
+      const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 14, minute: 30 }, hourCycle: '12' }))
+
+      const props = result.current.getFieldProps('hour')
+
+      expect(props['aria-valuemin']).toBe(1)
+      expect(props['aria-valuemax']).toBe(12)
+      expect(props['aria-valuenow']).toBe(2)
+      expect(props['aria-valuetext']).toBe('02')
+    })
+
+    it('minute returns correct ARIA attrs', () => {
+      const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 0, minute: 45 } }))
+
+      const props = result.current.getFieldProps('minute')
+
+      expect(props['aria-label']).toBe('Minute')
+      expect(props['aria-valuemin']).toBe(0)
+      expect(props['aria-valuemax']).toBe(59)
+      expect(props['aria-valuenow']).toBe(45)
+      expect(props['aria-valuetext']).toBe('45')
+    })
+
+    it('ampm returns correct ARIA attrs', () => {
+      const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 14, minute: 0 }, hourCycle: '12' }))
+
+      const props = result.current.getFieldProps('ampm')
+
+      expect(props['aria-label']).toBe('AM/PM')
+      expect(props['aria-valuemin']).toBe(0)
+      expect(props['aria-valuemax']).toBe(1)
+      expect(props['aria-valuenow']).toBe(1) // PM
+      expect(props['aria-valuetext']).toBe('PM')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Focus field
+  // ---------------------------------------------------------------------------
+  it('focusField changes which field has tabIndex=0', () => {
+    const { result } = renderHook(() => useTimePicker())
+
+    // Default focus is on hour
+    expect(result.current.getFieldProps('hour').tabIndex).toBe(0)
+    expect(result.current.getFieldProps('minute').tabIndex).toBe(-1)
+
+    act(() => {
+      result.current.actions.focusField('minute')
+    })
+
+    expect(result.current.getFieldProps('hour').tabIndex).toBe(-1)
+    expect(result.current.getFieldProps('minute').tabIndex).toBe(0)
+  })
+
+  it('focusField sets data-focused', () => {
+    const { result } = renderHook(() => useTimePicker())
+
+    expect(result.current.getFieldProps('hour')['data-focused']).toBe('true')
+    expect(result.current.getFieldProps('minute')['data-focused']).toBeUndefined()
+
+    act(() => {
+      result.current.actions.focusField('minute')
+    })
+
+    expect(result.current.getFieldProps('hour')['data-focused']).toBeUndefined()
+    expect(result.current.getFieldProps('minute')['data-focused']).toBe('true')
+  })
+
+  // ---------------------------------------------------------------------------
+  // setField
+  // ---------------------------------------------------------------------------
+  it('setField updates the specific field', () => {
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 0, minute: 0 } }))
+
+    act(() => {
+      result.current.actions.setField('hour', 15)
+    })
+
+    expect(result.current.state.value.hour).toBe(15)
+    expect(result.current.state.value.minute).toBe(0)
+  })
+
+  it('setField("minute") updates only minute', () => {
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 10, minute: 0 } }))
+
+    act(() => {
+      result.current.actions.setField('minute', 45)
+    })
+
+    expect(result.current.state.value.hour).toBe(10)
+    expect(result.current.state.value.minute).toBe(45)
+  })
+
+  // ---------------------------------------------------------------------------
+  // onChange callback
+  // ---------------------------------------------------------------------------
+  it('onChange is called when value changes', () => {
+    const onChange = vi.fn()
+    const { result } = renderHook(() => useTimePicker({ defaultValue: { hour: 0, minute: 0 }, onChange }))
+
+    act(() => {
+      result.current.actions.increment('hour')
+    })
+
+    expect(onChange).toHaveBeenCalledOnce()
+    expect(onChange).toHaveBeenCalledWith({ hour: 1, minute: 0 })
+  })
+})

--- a/packages/duck-calendar/src/react/use-time-picker/index.ts
+++ b/packages/duck-calendar/src/react/use-time-picker/index.ts
@@ -1,0 +1,2 @@
+export { useTimePicker } from './use-time-picker'
+export type { TimeFieldProps, UseTimePickerConfig, UseTimePickerReturn } from './use-time-picker.types'

--- a/packages/duck-calendar/src/react/use-time-picker/use-time-picker.ts
+++ b/packages/duck-calendar/src/react/use-time-picker/use-time-picker.ts
@@ -1,0 +1,295 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { incrementField, parseTimeInput } from '../../time/time'
+import { formatTimeField, getAmPm, to12Hour, to24Hour } from '../../time/time.libs'
+import type { TimeField, TimeValue } from '../../time/time.types'
+import { useControllableState } from '../utils/use-controllable-state'
+import type { TimeFieldProps, UseTimePickerConfig, UseTimePickerReturn } from './use-time-picker.types'
+
+// ---------------------------------------------------------------------------
+// Field ordering for tab-through
+// ---------------------------------------------------------------------------
+
+const FIELD_ORDER: TimeField[] = ['hour', 'minute', 'second', 'ampm']
+
+function nextField(current: TimeField, showSeconds: boolean, hourCycle: '12' | '24'): TimeField | null {
+  const available = FIELD_ORDER.filter((f) => {
+    if (f === 'second' && !showSeconds) return false
+    if (f === 'ampm' && hourCycle === '24') return false
+    return true
+  })
+  const idx = available.indexOf(current)
+  if (idx < 0 || idx >= available.length - 1) return null
+  return available[idx + 1]!
+}
+
+// ---------------------------------------------------------------------------
+// ARIA helpers
+// ---------------------------------------------------------------------------
+
+const FIELD_LABELS: Record<TimeField, string> = {
+  hour: 'Hour',
+  minute: 'Minute',
+  second: 'Second',
+  ampm: 'AM/PM',
+}
+
+function getFieldRange(field: TimeField, hourCycle: '12' | '24'): { min: number; max: number } {
+  switch (field) {
+    case 'hour':
+      return hourCycle === '12' ? { min: 1, max: 12 } : { min: 0, max: 23 }
+    case 'minute':
+    case 'second':
+      return { min: 0, max: 59 }
+    case 'ampm':
+      return { min: 0, max: 1 }
+  }
+}
+
+function getFieldNow(field: TimeField, value: TimeValue, hourCycle: '12' | '24'): number {
+  switch (field) {
+    case 'hour':
+      return hourCycle === '12' ? to12Hour(value.hour) : value.hour
+    case 'minute':
+      return value.minute
+    case 'second':
+      return value.second ?? 0
+    case 'ampm':
+      return value.hour < 12 ? 0 : 1
+  }
+}
+
+function getFieldText(field: TimeField, value: TimeValue, hourCycle: '12' | '24'): string {
+  switch (field) {
+    case 'hour':
+      return formatTimeField(hourCycle === '12' ? to12Hour(value.hour) : value.hour)
+    case 'minute':
+      return formatTimeField(value.minute)
+    case 'second':
+      return formatTimeField(value.second ?? 0)
+    case 'ampm':
+      return getAmPm(value.hour)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// useTimePicker
+// ---------------------------------------------------------------------------
+
+export function useTimePicker(config: UseTimePickerConfig = {}): UseTimePickerReturn {
+  const {
+    value: controlledValue,
+    defaultValue,
+    onChange,
+    hourCycle = '24',
+    showSeconds = false,
+    minTime,
+    maxTime,
+    minuteStep,
+    secondStep,
+  } = config
+
+  const initialValue: TimeValue = defaultValue ?? { hour: 0, minute: 0 }
+
+  const [value, setValueRaw] = useControllableState<TimeValue>(controlledValue, initialValue, onChange)
+
+  const [focusedField, setFocusedField] = useState<TimeField>('hour')
+
+  // Input buffering
+  const inputBuffer = useRef<string>('')
+  const inputTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Cleanup input timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (inputTimeout.current) clearTimeout(inputTimeout.current)
+    }
+  }, [])
+
+  // Derived display values
+  const displayHour = useMemo(() => (hourCycle === '12' ? to12Hour(value.hour) : value.hour), [value.hour, hourCycle])
+  const displayAmPm = useMemo(() => getAmPm(value.hour), [value.hour])
+
+  // -------------------------------------------------------------------------
+  // Actions
+  // -------------------------------------------------------------------------
+
+  const setValue = useCallback(
+    (next: TimeValue) => {
+      setValueRaw(next)
+    },
+    [setValueRaw],
+  )
+
+  const setField = useCallback(
+    (field: TimeField, fieldValue: number) => {
+      const next = { ...value }
+      switch (field) {
+        case 'hour':
+          next.hour = fieldValue
+          break
+        case 'minute':
+          next.minute = fieldValue
+          break
+        case 'second':
+          next.second = fieldValue
+          break
+        case 'ampm':
+          // 0 = AM, 1 = PM — convert current hour accordingly
+          next.hour = fieldValue === 0 ? value.hour % 12 : (value.hour % 12) + 12
+          break
+      }
+      setValueRaw(next)
+    },
+    [value, setValueRaw],
+  )
+
+  const increment = useCallback(
+    (field: TimeField, delta = 1) => {
+      const next = incrementField(value, field, delta, { hourCycle, minuteStep, secondStep, minTime, maxTime })
+      setValueRaw(next)
+    },
+    [value, setValueRaw, hourCycle, minuteStep, secondStep, minTime, maxTime],
+  )
+
+  const decrement = useCallback(
+    (field: TimeField, delta = 1) => {
+      const next = incrementField(value, field, -delta, { hourCycle, minuteStep, secondStep, minTime, maxTime })
+      setValueRaw(next)
+    },
+    [value, setValueRaw, hourCycle, minuteStep, secondStep, minTime, maxTime],
+  )
+
+  const toggleAmPm = useCallback(() => {
+    const currentAmPm = getAmPm(value.hour)
+    const hour12 = to12Hour(value.hour)
+    const newAmPm = currentAmPm === 'AM' ? 'PM' : 'AM'
+    const next = { ...value, hour: to24Hour(hour12, newAmPm) }
+    setValueRaw(next)
+  }, [value, setValueRaw])
+
+  const focusField = useCallback((field: TimeField) => {
+    setFocusedField(field)
+  }, [])
+
+  // -------------------------------------------------------------------------
+  // Digit input commit helper
+  // -------------------------------------------------------------------------
+
+  const commitBuffer = useCallback(
+    (field: TimeField, buffer: string) => {
+      const parsed = parseTimeInput(buffer, field, hourCycle)
+      if (parsed !== null) {
+        setField(field, parsed)
+      }
+      inputBuffer.current = ''
+      // Move to next field
+      const next = nextField(field, showSeconds, hourCycle)
+      if (next) setFocusedField(next)
+    },
+    [hourCycle, showSeconds, setField],
+  )
+
+  // -------------------------------------------------------------------------
+  // getFieldProps
+  // -------------------------------------------------------------------------
+
+  const getFieldProps = useCallback(
+    (field: TimeField): TimeFieldProps => {
+      const range = getFieldRange(field, hourCycle)
+      const now = getFieldNow(field, value, hourCycle)
+      const text = getFieldText(field, value, hourCycle)
+
+      const onKeyDown: React.KeyboardEventHandler = (e) => {
+        if (field === 'ampm') {
+          if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+            e.preventDefault()
+            toggleAmPm()
+            return
+          }
+          if (e.key === 'a' || e.key === 'A') {
+            e.preventDefault()
+            if (displayAmPm !== 'AM') toggleAmPm()
+            return
+          }
+          if (e.key === 'p' || e.key === 'P') {
+            e.preventDefault()
+            if (displayAmPm !== 'PM') toggleAmPm()
+            return
+          }
+          return
+        }
+
+        if (e.key === 'ArrowUp') {
+          e.preventDefault()
+          increment(field)
+          return
+        }
+        if (e.key === 'ArrowDown') {
+          e.preventDefault()
+          decrement(field)
+          return
+        }
+
+        // Digit input buffering
+        if (/^[0-9]$/.test(e.key)) {
+          e.preventDefault()
+          if (inputTimeout.current) clearTimeout(inputTimeout.current)
+          inputBuffer.current += e.key
+
+          if (inputBuffer.current.length >= 2) {
+            commitBuffer(field, inputBuffer.current)
+          } else {
+            inputTimeout.current = setTimeout(() => {
+              commitBuffer(field, inputBuffer.current)
+            }, 500)
+          }
+        }
+      }
+
+      const onFocus = () => {
+        setFocusedField(field)
+        // Clear any pending buffer from previous field
+        if (inputTimeout.current) clearTimeout(inputTimeout.current)
+        inputBuffer.current = ''
+      }
+
+      return {
+        role: 'spinbutton',
+        'aria-label': FIELD_LABELS[field],
+        'aria-valuemin': range.min,
+        'aria-valuemax': range.max,
+        'aria-valuenow': now,
+        'aria-valuetext': text,
+        tabIndex: focusedField === field ? 0 : -1,
+        'data-slot': 'time-picker-field',
+        'data-focused': focusedField === field ? 'true' : undefined,
+        onKeyDown,
+        onFocus,
+      }
+    },
+    [value, focusedField, hourCycle, increment, decrement, toggleAmPm, commitBuffer, displayAmPm],
+  )
+
+  // -------------------------------------------------------------------------
+  // Return
+  // -------------------------------------------------------------------------
+
+  return {
+    state: {
+      value,
+      focusedField,
+      hourCycle,
+      displayHour,
+      displayAmPm,
+    },
+    actions: {
+      setValue,
+      setField,
+      increment,
+      decrement,
+      toggleAmPm,
+      focusField,
+    },
+    getFieldProps,
+  }
+}

--- a/packages/duck-calendar/src/react/use-time-picker/use-time-picker.types.ts
+++ b/packages/duck-calendar/src/react/use-time-picker/use-time-picker.types.ts
@@ -1,0 +1,36 @@
+import type { HourCycle, TimeField, TimePickerConfig, TimeValue } from '../../time'
+
+export interface UseTimePickerConfig extends TimePickerConfig {}
+
+export interface TimeFieldProps {
+  role: 'spinbutton'
+  'aria-label': string
+  'aria-valuemin': number
+  'aria-valuemax': number
+  'aria-valuenow': number
+  'aria-valuetext': string
+  tabIndex: 0 | -1
+  'data-slot': string
+  'data-focused': 'true' | undefined
+  onKeyDown: React.KeyboardEventHandler
+  onFocus: () => void
+}
+
+export interface UseTimePickerReturn {
+  state: {
+    value: TimeValue
+    focusedField: TimeField
+    hourCycle: HourCycle
+    displayHour: number
+    displayAmPm: 'AM' | 'PM'
+  }
+  actions: {
+    setValue: (value: TimeValue) => void
+    setField: (field: TimeField, value: number) => void
+    increment: (field: TimeField, delta?: number) => void
+    decrement: (field: TimeField, delta?: number) => void
+    toggleAmPm: () => void
+    focusField: (field: TimeField) => void
+  }
+  getFieldProps: (field: TimeField) => TimeFieldProps
+}

--- a/packages/duck-calendar/src/react/utils/use-controllable-state.ts
+++ b/packages/duck-calendar/src/react/utils/use-controllable-state.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from 'react'
+
+/**
+ * Tiny controlled/uncontrolled state helper.
+ * If `controlled` is defined, it's used as the value. Otherwise, internal state manages it.
+ * `onChange` is always called when `setValue` is invoked.
+ */
+export function useControllableState<T>(
+  controlled: T | undefined,
+  uncontrolled: T,
+  onChange?: (val: T) => void,
+): [T, (val: T) => void] {
+  const [internal, setInternal] = useState<T>(uncontrolled)
+  const isControlled = controlled !== undefined
+
+  const value = isControlled ? controlled : internal
+
+  const setValue = useCallback(
+    (next: T) => {
+      if (!isControlled) setInternal(next)
+      onChange?.(next)
+    },
+    [isControlled, onChange],
+  )
+
+  return [value, setValue]
+}

--- a/packages/duck-calendar/src/time/__test__/time.test.ts
+++ b/packages/duck-calendar/src/time/__test__/time.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it } from 'vitest'
+import { clampTime, incrementField, isValidTime, parseTimeInput } from '../time'
+import { formatTimeField, getAmPm, to12Hour, to24Hour } from '../time.libs'
+
+describe('time', () => {
+  // ---------------------------------------------------------------------------
+  // isValidTime
+  // ---------------------------------------------------------------------------
+  describe('isValidTime', () => {
+    it('valid: { hour: 0, minute: 0 }', () => {
+      expect(isValidTime({ hour: 0, minute: 0 })).toBe(true)
+    })
+
+    it('valid: { hour: 23, minute: 59, second: 59 }', () => {
+      expect(isValidTime({ hour: 23, minute: 59, second: 59 })).toBe(true)
+    })
+
+    it('valid: { hour: 12, minute: 30 }', () => {
+      expect(isValidTime({ hour: 12, minute: 30 })).toBe(true)
+    })
+
+    it('valid: { hour: 0, minute: 0, second: 0 }', () => {
+      expect(isValidTime({ hour: 0, minute: 0, second: 0 })).toBe(true)
+    })
+
+    it('invalid: hour < 0', () => {
+      expect(isValidTime({ hour: -1, minute: 0 })).toBe(false)
+    })
+
+    it('invalid: hour > 23', () => {
+      expect(isValidTime({ hour: 24, minute: 0 })).toBe(false)
+    })
+
+    it('invalid: minute < 0', () => {
+      expect(isValidTime({ hour: 0, minute: -1 })).toBe(false)
+    })
+
+    it('invalid: minute > 59', () => {
+      expect(isValidTime({ hour: 0, minute: 60 })).toBe(false)
+    })
+
+    it('invalid: second < 0', () => {
+      expect(isValidTime({ hour: 0, minute: 0, second: -1 })).toBe(false)
+    })
+
+    it('invalid: second > 59', () => {
+      expect(isValidTime({ hour: 0, minute: 0, second: 60 })).toBe(false)
+    })
+
+    it('valid when second is undefined', () => {
+      expect(isValidTime({ hour: 10, minute: 30 })).toBe(true)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // clampTime
+  // ---------------------------------------------------------------------------
+  describe('clampTime', () => {
+    it('within bounds returns no change', () => {
+      const time = { hour: 10, minute: 30 }
+      const min = { hour: 8, minute: 0 }
+      const max = { hour: 18, minute: 0 }
+      expect(clampTime(time, min, max)).toEqual({ hour: 10, minute: 30 })
+    })
+
+    it('below min clamps to min', () => {
+      const time = { hour: 6, minute: 0 }
+      const min = { hour: 8, minute: 0 }
+      expect(clampTime(time, min)).toEqual({ hour: 8, minute: 0 })
+    })
+
+    it('above max clamps to max', () => {
+      const time = { hour: 20, minute: 0 }
+      const max = { hour: 18, minute: 0 }
+      expect(clampTime(time, undefined, max)).toEqual({ hour: 18, minute: 0 })
+    })
+
+    it('no min/max returns no change', () => {
+      const time = { hour: 14, minute: 45 }
+      expect(clampTime(time)).toEqual({ hour: 14, minute: 45 })
+    })
+
+    it('preserves second field presence when original has it', () => {
+      const time = { hour: 10, minute: 30, second: 15 }
+      const result = clampTime(time)
+      expect(result).toEqual({ hour: 10, minute: 30, second: 15 })
+      expect('second' in result).toBe(true)
+    })
+
+    it('strips second field when original lacks it', () => {
+      const time = { hour: 6, minute: 0 }
+      const min = { hour: 8, minute: 0, second: 30 }
+      const result = clampTime(time, min)
+      expect(result).toEqual({ hour: 8, minute: 0 })
+      expect('second' in result).toBe(false)
+    })
+
+    it('clamps using total seconds comparison (minute precision)', () => {
+      const time = { hour: 8, minute: 0 }
+      const min = { hour: 8, minute: 15 }
+      expect(clampTime(time, min)).toEqual({ hour: 8, minute: 15 })
+    })
+
+    it('exact min boundary is not clamped', () => {
+      const time = { hour: 8, minute: 0 }
+      const min = { hour: 8, minute: 0 }
+      expect(clampTime(time, min)).toEqual({ hour: 8, minute: 0 })
+    })
+
+    it('exact max boundary is not clamped', () => {
+      const time = { hour: 18, minute: 0 }
+      const max = { hour: 18, minute: 0 }
+      expect(clampTime(time, undefined, max)).toEqual({ hour: 18, minute: 0 })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // incrementField
+  // ---------------------------------------------------------------------------
+  describe('incrementField', () => {
+    it('hour: increments normally', () => {
+      const result = incrementField({ hour: 10, minute: 0 }, 'hour', 1)
+      expect(result.hour).toBe(11)
+    })
+
+    it('hour: wraps 23+1 to 0', () => {
+      const result = incrementField({ hour: 23, minute: 0 }, 'hour', 1)
+      expect(result.hour).toBe(0)
+    })
+
+    it('hour: wraps 0-1 to 23', () => {
+      const result = incrementField({ hour: 0, minute: 0 }, 'hour', -1)
+      expect(result.hour).toBe(23)
+    })
+
+    it('minute: increments normally', () => {
+      const result = incrementField({ hour: 10, minute: 30 }, 'minute', 1)
+      expect(result.minute).toBe(31)
+    })
+
+    it('minute: wraps 59+1 to 0', () => {
+      const result = incrementField({ hour: 10, minute: 59 }, 'minute', 1)
+      expect(result.minute).toBe(0)
+    })
+
+    it('minute: wraps 0-1 to 59', () => {
+      const result = incrementField({ hour: 10, minute: 0 }, 'minute', -1)
+      expect(result.minute).toBe(59)
+    })
+
+    it('second: increments normally', () => {
+      const result = incrementField({ hour: 10, minute: 0, second: 30 }, 'second', 1)
+      expect(result.second).toBe(31)
+    })
+
+    it('second: wraps 59+1 to 0', () => {
+      const result = incrementField({ hour: 10, minute: 0, second: 59 }, 'second', 1)
+      expect(result.second).toBe(0)
+    })
+
+    it('second: wraps 0-1 to 59', () => {
+      const result = incrementField({ hour: 10, minute: 0, second: 0 }, 'second', -1)
+      expect(result.second).toBe(59)
+    })
+
+    it('ampm: toggles AM to PM (0 -> 12)', () => {
+      const result = incrementField({ hour: 0, minute: 0 }, 'ampm', 1)
+      expect(result.hour).toBe(12)
+    })
+
+    it('ampm: toggles PM to AM (13 -> 1)', () => {
+      const result = incrementField({ hour: 13, minute: 0 }, 'ampm', 1)
+      expect(result.hour).toBe(1)
+    })
+
+    it('ampm: toggles PM to AM (12 -> 0)', () => {
+      const result = incrementField({ hour: 12, minute: 0 }, 'ampm', 1)
+      expect(result.hour).toBe(0)
+    })
+
+    it('ampm: toggles AM to PM (11 -> 23)', () => {
+      const result = incrementField({ hour: 11, minute: 0 }, 'ampm', 1)
+      expect(result.hour).toBe(23)
+    })
+
+    it('minuteStep: increment by 5 when step=5', () => {
+      const result = incrementField({ hour: 10, minute: 0 }, 'minute', 1, { minuteStep: 5 })
+      expect(result.minute).toBe(5)
+    })
+
+    it('minuteStep: decrement by 5 when step=5', () => {
+      const result = incrementField({ hour: 10, minute: 10 }, 'minute', -1, { minuteStep: 5 })
+      expect(result.minute).toBe(5)
+    })
+
+    it('minuteStep: wraps with step (55+5 -> 0)', () => {
+      const result = incrementField({ hour: 10, minute: 55 }, 'minute', 1, { minuteStep: 5 })
+      expect(result.minute).toBe(0)
+    })
+
+    it('secondStep: increment by 15 when step=15', () => {
+      const result = incrementField({ hour: 10, minute: 0, second: 0 }, 'second', 1, { secondStep: 15 })
+      expect(result.second).toBe(15)
+    })
+
+    it('respects min clamping after increment', () => {
+      const result = incrementField({ hour: 8, minute: 0 }, 'hour', -1, {
+        minTime: { hour: 8, minute: 0 },
+      })
+      expect(result.hour).toBe(8)
+      expect(result.minute).toBe(0)
+    })
+
+    it('respects max clamping after increment', () => {
+      const result = incrementField({ hour: 18, minute: 0 }, 'hour', 1, {
+        maxTime: { hour: 18, minute: 0 },
+      })
+      expect(result.hour).toBe(18)
+      expect(result.minute).toBe(0)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // parseTimeInput
+  // ---------------------------------------------------------------------------
+  describe('parseTimeInput', () => {
+    it('valid "14" for hour (24h) returns 14', () => {
+      expect(parseTimeInput('14', 'hour', '24')).toBe(14)
+    })
+
+    it('valid "0" for hour (24h) returns 0', () => {
+      expect(parseTimeInput('0', 'hour', '24')).toBe(0)
+    })
+
+    it('valid "23" for hour (24h) returns 23', () => {
+      expect(parseTimeInput('23', 'hour', '24')).toBe(23)
+    })
+
+    it('valid "2" for hour (12h) returns 2', () => {
+      expect(parseTimeInput('2', 'hour', '12')).toBe(2)
+    })
+
+    it('valid "1" for hour (12h) returns 1', () => {
+      expect(parseTimeInput('1', 'hour', '12')).toBe(1)
+    })
+
+    it('invalid "25" for hour (24h) returns null', () => {
+      expect(parseTimeInput('25', 'hour', '24')).toBeNull()
+    })
+
+    it('invalid "-1" for hour (24h) returns null', () => {
+      expect(parseTimeInput('-1', 'hour', '24')).toBeNull()
+    })
+
+    it('invalid "0" for hour (12h) returns null', () => {
+      expect(parseTimeInput('0', 'hour', '12')).toBeNull()
+    })
+
+    it('invalid "13" for hour (12h) returns null', () => {
+      expect(parseTimeInput('13', 'hour', '12')).toBeNull()
+    })
+
+    it('"12" in 12h mode returns 0 (noon/midnight)', () => {
+      expect(parseTimeInput('12', 'hour', '12')).toBe(0)
+    })
+
+    it('valid "30" for minute returns 30', () => {
+      expect(parseTimeInput('30', 'minute', '24')).toBe(30)
+    })
+
+    it('valid "0" for minute returns 0', () => {
+      expect(parseTimeInput('0', 'minute', '24')).toBe(0)
+    })
+
+    it('valid "59" for minute returns 59', () => {
+      expect(parseTimeInput('59', 'minute', '24')).toBe(59)
+    })
+
+    it('invalid "60" for minute returns null', () => {
+      expect(parseTimeInput('60', 'minute', '24')).toBeNull()
+    })
+
+    it('valid "45" for second returns 45', () => {
+      expect(parseTimeInput('45', 'second', '24')).toBe(45)
+    })
+
+    it('invalid "60" for second returns null', () => {
+      expect(parseTimeInput('60', 'second', '24')).toBeNull()
+    })
+
+    it('invalid "abc" returns null', () => {
+      expect(parseTimeInput('abc', 'hour', '24')).toBeNull()
+    })
+
+    it('invalid empty string returns null', () => {
+      expect(parseTimeInput('', 'hour', '24')).toBeNull()
+    })
+
+    it('"ampm" field returns null', () => {
+      expect(parseTimeInput('1', 'ampm', '24')).toBeNull()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // formatTimeField
+  // ---------------------------------------------------------------------------
+  describe('formatTimeField', () => {
+    it('0 returns "00"', () => {
+      expect(formatTimeField(0)).toBe('00')
+    })
+
+    it('5 returns "05"', () => {
+      expect(formatTimeField(5)).toBe('05')
+    })
+
+    it('9 returns "09"', () => {
+      expect(formatTimeField(9)).toBe('09')
+    })
+
+    it('14 returns "14"', () => {
+      expect(formatTimeField(14)).toBe('14')
+    })
+
+    it('59 returns "59"', () => {
+      expect(formatTimeField(59)).toBe('59')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // getAmPm
+  // ---------------------------------------------------------------------------
+  describe('getAmPm', () => {
+    it('hour 0 returns AM', () => {
+      expect(getAmPm(0)).toBe('AM')
+    })
+
+    it('hour 11 returns AM', () => {
+      expect(getAmPm(11)).toBe('AM')
+    })
+
+    it('hour 12 returns PM', () => {
+      expect(getAmPm(12)).toBe('PM')
+    })
+
+    it('hour 23 returns PM', () => {
+      expect(getAmPm(23)).toBe('PM')
+    })
+
+    it('hour 6 returns AM', () => {
+      expect(getAmPm(6)).toBe('AM')
+    })
+
+    it('hour 18 returns PM', () => {
+      expect(getAmPm(18)).toBe('PM')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // to12Hour
+  // ---------------------------------------------------------------------------
+  describe('to12Hour', () => {
+    it('0 returns 12 (midnight)', () => {
+      expect(to12Hour(0)).toBe(12)
+    })
+
+    it('1 returns 1', () => {
+      expect(to12Hour(1)).toBe(1)
+    })
+
+    it('11 returns 11', () => {
+      expect(to12Hour(11)).toBe(11)
+    })
+
+    it('12 returns 12 (noon)', () => {
+      expect(to12Hour(12)).toBe(12)
+    })
+
+    it('13 returns 1', () => {
+      expect(to12Hour(13)).toBe(1)
+    })
+
+    it('23 returns 11', () => {
+      expect(to12Hour(23)).toBe(11)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // to24Hour
+  // ---------------------------------------------------------------------------
+  describe('to24Hour', () => {
+    it('(12, AM) returns 0 (midnight)', () => {
+      expect(to24Hour(12, 'AM')).toBe(0)
+    })
+
+    it('(1, AM) returns 1', () => {
+      expect(to24Hour(1, 'AM')).toBe(1)
+    })
+
+    it('(11, AM) returns 11', () => {
+      expect(to24Hour(11, 'AM')).toBe(11)
+    })
+
+    it('(12, PM) returns 12 (noon)', () => {
+      expect(to24Hour(12, 'PM')).toBe(12)
+    })
+
+    it('(1, PM) returns 13', () => {
+      expect(to24Hour(1, 'PM')).toBe(13)
+    })
+
+    it('(11, PM) returns 23', () => {
+      expect(to24Hour(11, 'PM')).toBe(23)
+    })
+  })
+})

--- a/packages/duck-calendar/src/time/index.ts
+++ b/packages/duck-calendar/src/time/index.ts
@@ -1,0 +1,3 @@
+export { clampTime, incrementField, isValidTime, parseTimeInput } from './time'
+export { formatTimeField, getAmPm, to12Hour, to24Hour } from './time.libs'
+export type { HourCycle, TimeField, TimePickerConfig, TimeValue } from './time.types'

--- a/packages/duck-calendar/src/time/time.libs.ts
+++ b/packages/duck-calendar/src/time/time.libs.ts
@@ -1,0 +1,24 @@
+/** Pad a number to 2 digits. */
+export function formatTimeField(value: number): string {
+  return value.toString().padStart(2, '0')
+}
+
+/** Get AM or PM for a given 24-hour value. */
+export function getAmPm(hour: number): 'AM' | 'PM' {
+  return hour < 12 ? 'AM' : 'PM'
+}
+
+/** Convert 24-hour to 12-hour display value. 0→12, 13→1, etc. */
+export function to12Hour(hour: number): number {
+  if (hour === 0) return 12
+  if (hour > 12) return hour - 12
+  return hour
+}
+
+/** Convert 12-hour + AM/PM back to 24-hour. */
+export function to24Hour(hour12: number, ampm: 'AM' | 'PM'): number {
+  if (ampm === 'AM') {
+    return hour12 === 12 ? 0 : hour12
+  }
+  return hour12 === 12 ? 12 : hour12 + 12
+}

--- a/packages/duck-calendar/src/time/time.ts
+++ b/packages/duck-calendar/src/time/time.ts
@@ -1,0 +1,88 @@
+import type { HourCycle, TimeField, TimePickerConfig, TimeValue } from './time.types'
+
+/** Convert a TimeValue to total seconds for comparison. */
+function toSeconds(t: TimeValue): number {
+  return t.hour * 3600 + t.minute * 60 + (t.second ?? 0)
+}
+
+/** Check if a time value has valid ranges. */
+export function isValidTime(time: TimeValue): boolean {
+  if (time.hour < 0 || time.hour > 23) return false
+  if (time.minute < 0 || time.minute > 59) return false
+  if (time.second !== undefined && (time.second < 0 || time.second > 59)) return false
+  return true
+}
+
+/** Clamp a time value within min/max bounds. */
+export function clampTime(time: TimeValue, min?: TimeValue, max?: TimeValue): TimeValue {
+  let result = { ...time }
+  if (min && toSeconds(result) < toSeconds(min)) {
+    result = { ...min }
+  }
+  if (max && toSeconds(result) > toSeconds(max)) {
+    result = { ...max }
+  }
+  // Preserve the second field only if the original had it
+  if (time.second === undefined) {
+    const { second: _, ...rest } = result
+    return rest
+  }
+  return result
+}
+
+/** Increment or decrement a specific field, wrapping at boundaries. */
+export function incrementField(
+  time: TimeValue,
+  field: TimeField,
+  delta: number,
+  config: Pick<TimePickerConfig, 'hourCycle' | 'minuteStep' | 'secondStep' | 'minTime' | 'maxTime'> = {},
+): TimeValue {
+  const step = field === 'minute' ? (config.minuteStep ?? 1) : field === 'second' ? (config.secondStep ?? 1) : 1
+  const actualDelta = delta * step
+  const result = { ...time }
+
+  switch (field) {
+    case 'hour': {
+      result.hour = (((result.hour + actualDelta) % 24) + 24) % 24
+      break
+    }
+    case 'minute': {
+      result.minute = (((result.minute + actualDelta) % 60) + 60) % 60
+      break
+    }
+    case 'second': {
+      result.second = ((((result.second ?? 0) + actualDelta) % 60) + 60) % 60
+      break
+    }
+    case 'ampm': {
+      // Toggle AM/PM by adding/subtracting 12 hours
+      result.hour = (result.hour + 12) % 24
+      break
+    }
+  }
+
+  return clampTime(result, config.minTime, config.maxTime)
+}
+
+/** Parse a digit string typed by the user into a valid field value. Returns null if invalid. */
+export function parseTimeInput(input: string, field: TimeField, hourCycle: HourCycle): number | null {
+  const num = Number.parseInt(input, 10)
+  if (Number.isNaN(num)) return null
+
+  switch (field) {
+    case 'hour': {
+      const max = hourCycle === '12' ? 12 : 23
+      const min = hourCycle === '12' ? 1 : 0
+      if (num < min || num > max) return null
+      return hourCycle === '12' ? num % 12 : num // 12 in 12h mode → 0
+    }
+    case 'minute':
+      if (num < 0 || num > 59) return null
+      return num
+    case 'second':
+      if (num < 0 || num > 59) return null
+      return num
+    default:
+      return null
+  }
+}

--- a/packages/duck-calendar/src/time/time.types.ts
+++ b/packages/duck-calendar/src/time/time.types.ts
@@ -1,0 +1,37 @@
+/** A time value with hour, minute, and optional second. */
+export interface TimeValue {
+  /** 0–23 */
+  hour: number
+  /** 0–59 */
+  minute: number
+  /** 0–59 (optional) */
+  second?: number
+}
+
+/** Which time field is being edited. */
+export type TimeField = 'hour' | 'minute' | 'second' | 'ampm'
+
+/** Whether to display 12-hour or 24-hour format. */
+export type HourCycle = '12' | '24'
+
+/** Configuration for the time picker. */
+export interface TimePickerConfig {
+  /** Controlled time value. */
+  value?: TimeValue
+  /** Default time value for uncontrolled usage. */
+  defaultValue?: TimeValue
+  /** Called when the time changes. */
+  onChange?: (value: TimeValue) => void
+  /** 12-hour or 24-hour display. Default `'24'`. */
+  hourCycle?: HourCycle
+  /** Whether to show the seconds field. Default `false`. */
+  showSeconds?: boolean
+  /** Minimum selectable time. */
+  minTime?: TimeValue
+  /** Maximum selectable time. */
+  maxTime?: TimeValue
+  /** Step increment for minutes. Default `1`. */
+  minuteStep?: number
+  /** Step increment for seconds. Default `1`. */
+  secondStep?: number
+}


### PR DESCRIPTION
## Summary

- Add `useTimePicker` hook with spinbutton ARIA, 12/24h support, digit input buffering
- Add `useDateTime` hook composing useCalendar (single mode) + useTimePicker
- Add multi-month layout support via `numberOfMonths` config
- Time picker features: increment/decrement, AM/PM toggle, min/max constraints, minute/second steps
- 21 useTimePicker tests, 9 useDateTime tests

## Test plan

- [ ] `npx turbo run test --filter=@gentleduck/calendar`
- [ ] Verify time picker digit input buffering (type "14" for 2pm)
- [ ] Verify datetime picker preserves time on date selection and vice versa
- [ ] Verify multi-month renders correct number of month grids

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-month calendar display—configure how many months appear side-by-side
  * Added time picker with digit entry, arrow keys for stepping, and AM/PM toggling  
  * Added datetime picker combining calendar and time selection—date changes preserve time and vice versa
  * Extended date handling to support time component getters and setters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->