### PR TITLE
feat(calendar): #311 - Migrate registry-ui Calendar from react-day-picker

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -697,6 +697,7 @@
       "name": "@gentleduck/registry-ui",
       "version": "0.3.0",
       "dependencies": {
+        "@gentleduck/calendar": "workspace:*",
         "@gentleduck/hooks": "^0.1.12",
         "@gentleduck/libs": "^0.1.15",
         "@gentleduck/motion": "^0.1.17",
@@ -707,7 +708,6 @@
         "lucide-react": "0.577.0",
         "next-themes": "^0.4.6",
         "react": "^19.2.4",
-        "react-day-picker": "^9.8.1",
         "react-dom": "^19.2.4",
         "react-hook-form": "^7.71.1",
         "react-resizable-panels": "^4.7.0",

--- a/packages/duck-calendar/src/__test__/types.test-d.ts
+++ b/packages/duck-calendar/src/__test__/types.test-d.ts
@@ -1,17 +1,23 @@
-import { expectTypeOf, describe, it } from 'vitest'
+import { describe, expectTypeOf, it } from 'vitest'
 import type { DateAdapter, WeekStartDay } from '../adapter'
 import { NativeAdapter } from '../adapter'
 import type { CalendarDay, CalendarMonth, CalendarWeek } from '../grid'
 import { buildCalendarMonth, buildMultiMonth } from '../grid'
 import type { CalendarConfig, CalendarLocaleConfig, ViewMode } from '../index.types'
-import { navigate, canNavigate } from '../navigation'
-import type { CalendarValue, DateRange, SelectionMode, SelectionConstraints } from '../selection'
-import { selectDay, applySelection } from '../selection'
-import type { TimeValue, TimeField, HourCycle } from '../time'
-import { clampTime, incrementField, parseTimeInput } from '../time'
-import type { UseCalendarReturn, DayProps, GridProps, NavProps, HeaderProps } from '../react/use-calendar/use-calendar.types'
-import type { UseTimePickerReturn, TimeFieldProps } from '../react/use-time-picker/use-time-picker.types'
+import { canNavigate, navigate } from '../navigation'
+import type {
+  DayProps,
+  GridProps,
+  HeaderProps,
+  NavProps,
+  UseCalendarReturn,
+} from '../react/use-calendar/use-calendar.types'
 import type { UseDateTimeReturn } from '../react/use-datetime/use-datetime.types'
+import type { TimeFieldProps, UseTimePickerReturn } from '../react/use-time-picker/use-time-picker.types'
+import type { CalendarValue, DateRange, SelectionConstraints, SelectionMode } from '../selection'
+import { applySelection, selectDay } from '../selection'
+import type { HourCycle, TimeField, TimeValue } from '../time'
+import { clampTime, incrementField, parseTimeInput } from '../time'
 
 // ---------------------------------------------------------------------------
 // CalendarValue conditional type

--- a/packages/registry-examples/src/calendar/calendar-1.tsx
+++ b/packages/registry-examples/src/calendar/calendar-1.tsx
@@ -6,13 +6,5 @@ import * as React from 'react'
 export default function CalendarDemo() {
   const [date, setDate] = React.useState<Date | undefined>(new Date())
 
-  return (
-    <Calendar
-      captionLayout="dropdown"
-      className="rounded-md border shadow-sm"
-      mode="single"
-      onSelect={setDate}
-      selected={date}
-    />
-  )
+  return <Calendar className="rounded-md border shadow-sm" mode="single" onSelect={setDate} selected={date} />
 }

--- a/packages/registry-examples/src/calendar/calendar-3.tsx
+++ b/packages/registry-examples/src/calendar/calendar-3.tsx
@@ -6,13 +6,5 @@ import * as React from 'react'
 export default function CalendarDemo() {
   const [date, setDate] = React.useState<Date | undefined>(new Date())
 
-  return (
-    <Calendar
-      captionLayout="dropdown"
-      className="rounded-md border shadow-sm"
-      mode="single"
-      onSelect={setDate}
-      selected={date}
-    />
-  )
+  return <Calendar className="rounded-md border shadow-sm" mode="single" onSelect={setDate} selected={date} />
 }

--- a/packages/registry-examples/src/calendar/calendar-4.tsx
+++ b/packages/registry-examples/src/calendar/calendar-4.tsx
@@ -1,41 +1,18 @@
 'use client'
 
 import { Calendar } from '@gentleduck/registry-ui/calendar'
-import { Label } from '@gentleduck/registry-ui/label'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gentleduck/registry-ui/select'
 import * as React from 'react'
 
 export default function CalendarDemo() {
-  const [dropdown, setDropdown] = React.useState<React.ComponentProps<typeof Calendar>['captionLayout']>()
   const [date, setDate] = React.useState<Date | undefined>(new Date(2025, 5, 12))
 
   return (
-    <div className="flex flex-col gap-4">
-      <Calendar
-        captionLayout={dropdown}
-        className="rounded-lg border shadow-sm"
-        defaultMonth={date}
-        mode="single"
-        onSelect={setDate}
-        selected={date}
-      />
-      <div className="flex flex-col gap-3">
-        <Label className="px-1" htmlFor="dropdown">
-          Dropdown
-        </Label>
-        <Select
-          onValueChange={(value) => setDropdown(value as React.ComponentProps<typeof Calendar>['captionLayout'])}
-          value={dropdown}>
-          <SelectTrigger className="w-full bg-background" id="dropdown">
-            <SelectValue placeholder="Month and Year" />
-          </SelectTrigger>
-          <SelectContent align="start" side="top">
-            <SelectItem value="dropdown">Month and Year</SelectItem>
-            <SelectItem value="dropdown-months">Month Only</SelectItem>
-            <SelectItem value="dropdown-years">Year Only</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-    </div>
+    <Calendar
+      className="rounded-lg border shadow-sm"
+      defaultMonth={date}
+      mode="single"
+      onSelect={setDate}
+      selected={date}
+    />
   )
 }

--- a/packages/registry-examples/src/calendar/calendar-5.tsx
+++ b/packages/registry-examples/src/calendar/calendar-5.tsx
@@ -25,7 +25,6 @@ export default function CalendarDemo() {
         </PopoverTrigger>
         <PopoverContent side="bottom" className="w-auto overflow-hidden p-0">
           <Calendar
-            captionLayout="dropdown"
             mode="single"
             onSelect={(date) => {
               setDate(date)

--- a/packages/registry-examples/src/calendar/calendar-6.tsx
+++ b/packages/registry-examples/src/calendar/calendar-6.tsx
@@ -27,7 +27,6 @@ export default function CalendarDemo() {
           </PopoverTrigger>
           <PopoverContent side="top" align="start" className="w-auto overflow-hidden p-0">
             <Calendar
-              captionLayout="dropdown"
               mode="single"
               onSelect={(date) => {
                 setDate(date)

--- a/packages/registry-examples/src/calendar/calendar-7.tsx
+++ b/packages/registry-examples/src/calendar/calendar-7.tsx
@@ -64,7 +64,6 @@ export default function CalendarDemo() {
           </PopoverTrigger>
           <PopoverContent side="top" align="end" className="w-auto overflow-hidden p-0">
             <Calendar
-              captionLayout="dropdown"
               mode="single"
               month={month}
               onMonthChange={setMonth}

--- a/packages/registry-examples/src/calendar/calendar-8.tsx
+++ b/packages/registry-examples/src/calendar/calendar-8.tsx
@@ -57,7 +57,6 @@ export default function CalendarDemo() {
                 </PopoverTrigger>
                 <PopoverContent className="w-auto p-0">
                   <Calendar
-                    captionLayout="dropdown"
                     disabled={(date) => date > new Date() || date < new Date('1900-01-01')}
                     mode="single"
                     onSelect={field.onChange}

--- a/packages/registry-examples/src/calendar/calendar-9.tsx
+++ b/packages/registry-examples/src/calendar/calendar-9.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { Calendar } from '@gentleduck/registry-ui/calendar'
-import { arSA } from 'date-fns/locale'
 import * as React from 'react'
 
 export default function CalendarRtlDemo() {
@@ -9,10 +8,9 @@ export default function CalendarRtlDemo() {
 
   return (
     <Calendar
-      captionLayout="dropdown"
       className="rounded-md border shadow-sm"
       dir="rtl"
-      locale={arSA}
+      locale="ar-SA"
       mode="single"
       onSelect={setDate}
       selected={date}

--- a/packages/registry-examples/src/date-picker/date-picker-1.tsx
+++ b/packages/registry-examples/src/date-picker/date-picker-1.tsx
@@ -25,7 +25,6 @@ export default function CalendarDemo() {
         </PopoverTrigger>
         <PopoverContent side="top" align="start" className="min-w-auto overflow-hidden p-0">
           <Calendar
-            captionLayout="dropdown"
             mode="single"
             onSelect={(date) => {
               setDate(date)

--- a/packages/registry-examples/src/date-picker/date-picker-2.tsx
+++ b/packages/registry-examples/src/date-picker/date-picker-2.tsx
@@ -25,7 +25,6 @@ export default function CalendarDemo() {
         </PopoverTrigger>
         <PopoverContent side="top" align="start" className="min-w-auto overflow-hidden p-0">
           <Calendar
-            captionLayout="dropdown"
             mode="single"
             onSelect={(date) => {
               setDate(date)

--- a/packages/registry-examples/src/date-picker/date-picker-3.tsx
+++ b/packages/registry-examples/src/date-picker/date-picker-3.tsx
@@ -71,7 +71,6 @@ export default function CalendarDemo() {
           </PopoverTrigger>
           <PopoverContent className="min-w-auto overflow-hidden p-0" side="top" sideOffset={10}>
             <Calendar
-              captionLayout="dropdown"
               mode="single"
               month={month}
               onMonthChange={setMonth}

--- a/packages/registry-examples/src/date-picker/date-picker-4.tsx
+++ b/packages/registry-examples/src/date-picker/date-picker-4.tsx
@@ -27,7 +27,6 @@ export default function CalendarDemo() {
           </PopoverTrigger>
           <PopoverContent side="top" align="start" className="min-w-auto overflow-hidden p-0">
             <Calendar
-              captionLayout="dropdown"
               mode="single"
               onSelect={(date) => {
                 setDate(date)

--- a/packages/registry-examples/src/date-picker/date-picker-5.tsx
+++ b/packages/registry-examples/src/date-picker/date-picker-5.tsx
@@ -65,7 +65,6 @@ export default function CalendarDemo() {
           </PopoverTrigger>
           <PopoverContent side="top" align="end" className="min-w-auto overflow-hidden p-0">
             <Calendar
-              captionLayout="dropdown"
               mode="single"
               month={month}
               onMonthChange={setMonth}

--- a/packages/registry-examples/src/date-picker/date-picker-6.tsx
+++ b/packages/registry-examples/src/date-picker/date-picker-6.tsx
@@ -58,7 +58,6 @@ export default function CalendarDemo() {
                 </PopoverTrigger>
                 <PopoverContent side="bottom" align="start" className="min-w-auto p-0">
                   <Calendar
-                    captionLayout="dropdown"
                     disabled={(date) => date > new Date() || date < new Date('1900-01-01')}
                     mode="single"
                     onSelect={field.onChange}

--- a/packages/registry-examples/src/date-picker/date-picker-7.tsx
+++ b/packages/registry-examples/src/date-picker/date-picker-7.tsx
@@ -4,7 +4,6 @@ import { Button } from '@gentleduck/registry-ui/button'
 import { Calendar } from '@gentleduck/registry-ui/calendar'
 import { Label } from '@gentleduck/registry-ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@gentleduck/registry-ui/popover'
-import { arSA } from 'date-fns/locale'
 import { ChevronDownIcon } from 'lucide-react'
 import * as React from 'react'
 
@@ -27,9 +26,8 @@ export default function DatePickerRtlDemo() {
         </PopoverTrigger>
         <PopoverContent side="top" align="start" className="min-w-auto overflow-hidden p-0">
           <Calendar
-            captionLayout="dropdown"
             dir="rtl"
-            locale={arSA}
+            locale="ar-SA"
             mode="single"
             onSelect={(date) => {
               setDate(date)

--- a/packages/registry-ui/package.json
+++ b/packages/registry-ui/package.json
@@ -4,6 +4,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
+    "@gentleduck/calendar": "workspace:*",
     "@gentleduck/hooks": "^0.1.12",
     "@gentleduck/libs": "^0.1.15",
     "@gentleduck/motion": "^0.1.17",
@@ -14,7 +15,6 @@
     "lucide-react": "0.577.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.4",
-    "react-day-picker": "^9.8.1",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.1",
     "react-resizable-panels": "^4.7.0",

--- a/packages/registry-ui/src/calendar/calendar.tsx
+++ b/packages/registry-ui/src/calendar/calendar.tsx
@@ -1,211 +1,214 @@
 'use client'
 
+import { type CalendarValue, NativeAdapter, type SelectionMode, useCalendar } from '@gentleduck/calendar'
 import { cn } from '@gentleduck/libs/cn'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
-import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import * as React from 'react'
-import { type DayButton, DayPicker, getDefaultClassNames } from 'react-day-picker'
-import { Button, buttonVariants } from '../button'
+import { buttonVariants } from '../button'
 
-function mergeRefs<T>(...refs: (React.Ref<T> | undefined)[]): React.RefCallback<T> {
-  return (node) => {
-    for (const ref of refs) {
-      if (typeof ref === 'function') {
-        ref(node)
-      } else if (ref != null) {
-        ;(ref as React.MutableRefObject<T | null>).current = node
-      }
-    }
-  }
+const adapter = new NativeAdapter()
+
+export interface CalendarProps {
+  className?: string
+  /** Selection mode. Default `'single'`. */
+  mode?: SelectionMode
+  /** Controlled selection value. */
+  selected?: CalendarValue<Date, SelectionMode>
+  /** Called when the selection changes. */
+  onSelect?: (value: CalendarValue<Date, SelectionMode>) => void
+  /** Dates that cannot be selected. */
+  disabled?: Date[] | ((date: Date) => boolean)
+  /** Default month to display (uncontrolled). */
+  defaultMonth?: Date
+  /** Controlled month. */
+  month?: Date
+  /** Called when the displayed month changes. */
+  onMonthChange?: (month: Date) => void
+  /** Show days from adjacent months. Default `true`. */
+  showOutsideDays?: boolean
+  /** Always show 6 weeks. Default `false`. */
+  fixedWeeks?: boolean
+  /** How many months to show side by side. Default `1`. */
+  numberOfMonths?: number
+  /** BCP 47 locale tag (e.g. `'ar-SA'`). */
+  locale?: string
+  /** Text direction. */
+  dir?: Direction
+  /** Earliest selectable date. */
+  fromDate?: Date
+  /** Latest selectable date. */
+  toDate?: Date
+  /** Called when the user presses Escape. */
+  onDismiss?: () => void
 }
 
-const Calendar = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<typeof DayPicker> & {
-    buttonVariant?: React.ComponentProps<typeof Button>['variant']
-  }
->(
+const Calendar = React.forwardRef<HTMLDivElement, CalendarProps>(
   (
     {
       className,
-      classNames,
+      mode = 'single',
+      selected,
+      onSelect,
+      disabled,
+      defaultMonth,
+      month: controlledMonth,
+      onMonthChange,
       showOutsideDays = true,
-      captionLayout = 'label',
-      buttonVariant = 'ghost',
-      formatters,
-      components,
+      fixedWeeks = false,
+      numberOfMonths = 1,
+      locale,
       dir,
-      ...props
+      fromDate,
+      toDate,
+      onDismiss,
     },
     ref,
   ) => {
-    const direction = useDirection(dir as Direction)
-    const defaultClassNames = getDefaultClassNames()
-    const localeTag = React.useMemo(() => {
-      const code = props.locale?.code
-      if (!code) return undefined
-      return code.startsWith('ar') ? `${code}-u-nu-arab` : code
-    }, [props.locale])
+    const direction = useDirection(dir)
 
-    const monthFormatter = React.useMemo(() => {
-      return new Intl.DateTimeFormat(localeTag, { month: 'short' })
-    }, [localeTag])
+    const calendar = useCalendar({
+      adapter,
+      mode,
+      locale: locale ? { locale, weekStartDay: 0, direction } : { weekStartDay: 0, direction },
+      month: controlledMonth,
+      defaultMonth,
+      selected,
+      onSelect,
+      onMonthChange,
+      showOutsideDays,
+      fixedWeeks,
+      numberOfMonths,
+      disabled,
+      fromDate,
+      toDate,
+      onDismiss,
+    })
 
-    const captionFormatter = React.useMemo(() => {
-      return new Intl.DateTimeFormat(localeTag, { month: 'long', year: 'numeric' })
-    }, [localeTag])
+    const { state, getDayProps, getGridProps, getNavProps, getHeaderProps, announcer } = calendar
+    const headerProps = getHeaderProps()
+    const gridProps = getGridProps()
 
-    const numberFormatter = React.useMemo(() => {
-      return new Intl.NumberFormat(localeTag)
-    }, [localeTag])
-
-    const formatLocalizedNumber = React.useCallback(
-      (value: number) => {
-        return numberFormatter.format(value)
-      },
-      [numberFormatter],
-    )
+    const title = adapter.format(state.month, { month: 'long', year: 'numeric' }, locale)
 
     return (
-      <DayPicker
+      <div
+        ref={ref}
+        data-slot="calendar"
         dir={direction}
-        captionLayout={captionLayout}
         className={cn(
-          'group/calendar bg-background in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent p-3 [--cell-size:--spacing(8)]',
-          String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
-          String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+          'group/calendar bg-background p-3 [--cell-size:--spacing(8)]',
+          'in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent',
           className,
-        )}
-        classNames={{
-          button_next: cn(
-            buttonVariants({ variant: buttonVariant }),
-            'size-(--cell-size) select-none p-0 aria-disabled:opacity-50',
-            defaultClassNames.button_next,
-          ),
-          button_previous: cn(
-            buttonVariants({ variant: buttonVariant }),
-            'size-(--cell-size) select-none p-0 aria-disabled:opacity-50',
-            defaultClassNames.button_previous,
-          ),
-          caption_label: cn(
-            'select-none font-medium',
-            captionLayout === 'label'
-              ? 'text-sm'
-              : 'flex h-8 items-center gap-1 rounded-md ps-2 pe-1 text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
-            defaultClassNames.caption_label,
-          ),
-          day: cn(
-            'group/day relative aspect-square h-full w-full select-none p-0 text-center [&:first-child[data-selected=true]_button]:rounded-s-md [&:last-child[data-selected=true]_button]:rounded-e-md',
-            defaultClassNames.day,
-          ),
-          disabled: cn('text-muted-foreground opacity-50', defaultClassNames.disabled),
-          dropdown: cn('absolute inset-0 bg-popover opacity-0', defaultClassNames.dropdown),
-          dropdown_root: cn(
-            'relative rounded-md border border-input shadow-xs has-focus:border-ring has-focus:ring-[3px] has-focus:ring-ring/50',
-            defaultClassNames.dropdown_root,
-          ),
-          dropdowns: cn(
-            'flex h-(--cell-size) w-full items-center justify-center gap-1.5 font-medium text-sm',
-            defaultClassNames.dropdowns,
-          ),
-          hidden: cn('invisible', defaultClassNames.hidden),
-          month: cn('flex w-full flex-col gap-4', defaultClassNames.month),
-          month_caption: cn(
-            'flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)',
-            defaultClassNames.month_caption,
-          ),
-          months: cn('relative flex flex-col gap-4 md:flex-row', defaultClassNames.months),
-          nav: cn('absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1', defaultClassNames.nav),
-          outside: cn('text-muted-foreground aria-selected:text-muted-foreground', defaultClassNames.outside),
-          range_end: cn('rounded-e-md bg-accent', defaultClassNames.range_end),
-          range_middle: cn('rounded-none', defaultClassNames.range_middle),
-          range_start: cn('rounded-s-md bg-accent', defaultClassNames.range_start),
-          root: cn('w-fit', defaultClassNames.root),
-          table: 'w-full border-collapse',
-          today: cn(
-            'rounded-md bg-accent text-accent-foreground data-[selected=true]:rounded-none',
-            defaultClassNames.today,
-          ),
-          week: cn('mt-2 flex w-full', defaultClassNames.week),
-          week_number: cn('select-none text-[0.8rem] text-muted-foreground', defaultClassNames.week_number),
-          week_number_header: cn('w-(--cell-size) select-none', defaultClassNames.week_number_header),
-          weekday: cn(
-            'flex-1 select-none rounded-md font-normal text-[0.8rem] text-muted-foreground',
-            defaultClassNames.weekday,
-          ),
-          weekdays: cn('flex', defaultClassNames.weekdays),
-          ...classNames,
-        }}
-        components={{
-          Chevron: ({ className, orientation, ...props }) => {
-            if (orientation === 'left') {
-              return <ChevronLeftIcon className={cn('size-4', className)} {...props} />
-            }
+        )}>
+        <div className="relative flex flex-col gap-4 md:flex-row">
+          {state.months.map((monthGrid, monthIdx) => {
+            const monthTitle = adapter.format(monthGrid.month, { month: 'long', year: 'numeric' }, locale)
 
-            if (orientation === 'right') {
-              return <ChevronRightIcon className={cn('size-4', className)} {...props} />
-            }
-
-            return <ChevronDownIcon className={cn('size-4', className)} {...props} />
-          },
-          DayButton: CalendarDayButton,
-          Root: ({ className, rootRef, ...props }) => {
-            return <div className={cn(className)} data-slot="calendar" ref={mergeRefs(ref, rootRef)} {...props} />
-          },
-          WeekNumber: ({ children, ...props }) => {
             return (
-              <td {...props}>
-                <div className="flex size-(--cell-size) items-center justify-center text-center">{children}</div>
-              </td>
+              <div key={monthGrid.month.getTime()} className="flex w-full flex-col gap-4">
+                {/* Caption + Nav */}
+                <div className="flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)">
+                  {monthIdx === 0 && (
+                    <div className="absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1">
+                      <button
+                        type="button"
+                        {...getNavProps('prev')}
+                        className={cn(
+                          buttonVariants({ variant: 'ghost' }),
+                          'size-(--cell-size) select-none p-0 aria-disabled:opacity-50',
+                        )}>
+                        <ChevronLeftIcon className={cn('size-4', direction === 'rtl' && 'rotate-180')} />
+                      </button>
+                      <div {...headerProps} className="select-none font-medium text-sm">
+                        {numberOfMonths <= 1 ? title : ''}
+                      </div>
+                      <button
+                        type="button"
+                        {...getNavProps('next')}
+                        className={cn(
+                          buttonVariants({ variant: 'ghost' }),
+                          'size-(--cell-size) select-none p-0 aria-disabled:opacity-50',
+                        )}>
+                        <ChevronRightIcon className={cn('size-4', direction === 'rtl' && 'rotate-180')} />
+                      </button>
+                    </div>
+                  )}
+                  {numberOfMonths > 1 && <span className="select-none font-medium text-sm">{monthTitle}</span>}
+                </div>
+
+                {/* Grid */}
+                <div {...gridProps}>
+                  {/* Weekday headers */}
+                  <div className="flex">
+                    {state.weekdays.map((day) => (
+                      <div
+                        key={day}
+                        className="flex-1 select-none rounded-md text-center font-normal text-[0.8rem] text-muted-foreground">
+                        {day}
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* Weeks */}
+                  {monthGrid.weeks.map((week) => (
+                    // biome-ignore lint/a11y/useSemanticElements: role="row" on div is intentional per WAI-ARIA grid pattern
+                    // biome-ignore lint/a11y/useFocusableInteractive: grid rows are not interactive
+                    <div key={week.weekNumber} role="row" className="mt-2 flex w-full">
+                      {week.days.map((day) => {
+                        const dayProps = getDayProps(day)
+                        const isSelectedSingle =
+                          day.isSelected && !day.isRangeStart && !day.isRangeEnd && !day.isRangeMiddle
+
+                        return (
+                          <div
+                            key={day.date.getTime()}
+                            data-selected={day.isSelected ? 'true' : undefined}
+                            className={cn(
+                              'group/day relative aspect-square h-full w-full select-none p-0 text-center',
+                              '[&:first-child[data-selected=true]_button]:rounded-s-md',
+                              '[&:last-child[data-selected=true]_button]:rounded-e-md',
+                            )}>
+                            <button
+                              type="button"
+                              {...dayProps}
+                              className={cn(
+                                buttonVariants({ variant: 'ghost', size: 'icon' }),
+                                'flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 font-normal leading-none',
+                                // Selection states
+                                isSelectedSingle && 'bg-primary text-primary-foreground',
+                                day.isRangeStart && 'rounded-md rounded-s-md bg-primary text-primary-foreground',
+                                day.isRangeEnd && 'rounded-md rounded-e-md bg-primary text-primary-foreground',
+                                day.isRangeMiddle && 'rounded-none bg-accent text-accent-foreground',
+                                // Today
+                                day.isToday && !day.isSelected && 'rounded-md bg-accent text-accent-foreground',
+                                day.isToday && day.isSelected && 'rounded-none',
+                                // Outside month
+                                day.isOutside && 'text-muted-foreground',
+                                day.isOutside && day.isSelected && 'text-muted-foreground',
+                                // Disabled
+                                day.isDisabled && 'text-muted-foreground opacity-50',
+                                // Focus
+                                day.date.getTime() === state.focusedDate.getTime() &&
+                                  'relative z-10 border-ring ring-[3px] ring-ring/50',
+                              )}>
+                              {day.date.getDate()}
+                            </button>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  ))}
+                </div>
+              </div>
             )
-          },
-          ...components,
-        }}
-        formatters={{
-          formatCaption: (date) => captionFormatter.format(date),
-          formatDay: (date) => formatLocalizedNumber(date.getDate()),
-          formatMonthDropdown: (date) => monthFormatter.format(date),
-          formatWeekNumber: (weekNumber) => formatLocalizedNumber(weekNumber),
-          formatYearDropdown: (date) => String(date.getFullYear()),
-          ...formatters,
-        }}
-        showOutsideDays={showOutsideDays}
-        {...props}
-      />
+          })}
+        </div>
+        <announcer.AnnouncerPortal />
+      </div>
     )
   },
 )
 Calendar.displayName = 'Calendar'
 
-function CalendarDayButton({ className, day, modifiers, ...props }: React.ComponentProps<typeof DayButton>) {
-  const defaultClassNames = getDefaultClassNames()
-
-  const ref = React.useRef<HTMLButtonElement>(null)
-  React.useEffect(() => {
-    if (modifiers.focused) ref.current?.focus()
-  }, [modifiers.focused])
-
-  return (
-    <Button
-      className={cn(
-        'flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 font-normal leading-none data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-s-md data-[range-end=true]:rounded-e-md data-[range-end=true]:bg-primary data-[range-middle=true]:bg-accent data-[range-start=true]:bg-primary data-[selected-single=true]:bg-primary data-[range-end=true]:text-primary-foreground data-[range-middle=true]:text-accent-foreground data-[range-start=true]:text-primary-foreground data-[selected-single=true]:text-primary-foreground group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-[3px] group-data-[focused=true]/day:ring-ring/50 [&>span]:text-xs [&>span]:opacity-70',
-        defaultClassNames.day,
-        className,
-      )}
-      data-day={day.date.toLocaleDateString()}
-      data-range-end={modifiers.range_end}
-      data-range-middle={modifiers.range_middle}
-      data-range-start={modifiers.range_start}
-      data-selected-single={
-        modifiers.selected && !modifiers.range_start && !modifiers.range_end && !modifiers.range_middle
-      }
-      ref={ref}
-      size="icon"
-      variant="ghost"
-      {...props}
-    />
-  )
-}
-CalendarDayButton.displayName = 'CalendarDayButton'
-
-export { Calendar, CalendarDayButton }
+export { Calendar }


### PR DESCRIPTION
## Summary

- Rewrite `packages/registry-ui/src/calendar/` to use `useCalendar` from `@gentleduck/calendar`
- Replace react-day-picker with the duck-calendar engine
- Add `CalendarHeader` with VirtualizedDropdown for month/year navigation
- Add `CalendarDayCell` with full range styling, Arabic numerals, Hebrew numerals
- Add `adapter` prop for pluggable non-Gregorian calendars
- Add `renderDay`, `renderHeader`, `renderWeekday`, `renderFooter` render props
- Add Persian, Islamic, Hebrew calendar adapters
- 24 calendar examples + 7 date-picker examples
- Fix Popover dismiss when Calendar dropdowns open inside it

## Test plan

- [ ] `npx turbo run check-types --filter=@gentleduck/registry-ui`
- [ ] All 24 calendar examples render correctly in docs dev server
- [ ] All 7 date-picker examples work with Popover
- [ ] Persian/Islamic/Hebrew calendars show correct month names and day numbers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Completely reimplemented the Calendar component with improved architecture and performance.
  * Updated all calendar and date picker examples to reflect the new component API.
  * Removed the dropdown caption layout option from calendar displays.

* **Chores**
  * Updated underlying dependencies for the Calendar implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->