### PR TITLE
docs(calendar): #312 - Documentation, examples, and API reference

### DIFF
--- a/apps/duck-ui-docs/config/docs.ts
+++ b/apps/duck-ui-docs/config/docs.ts
@@ -789,6 +789,12 @@ export const docsConfig: DocsConfig = {
           title: 'Gentleduck State',
         },
         {
+          href: '/docs/packages/duck-calendar',
+          items: [],
+          label: 'new',
+          title: 'Gentleduck Calendar',
+        },
+        {
           href: '/docs/packages/duck-shortcut',
           items: [],
           title: 'Gentleduck Shortcut (Deprecated)',

--- a/apps/duck-ui-docs/content/docs/components/calendar.mdx
+++ b/apps/duck-ui-docs/content/docs/components/calendar.mdx
@@ -3,7 +3,7 @@ title: calendar
 description: A date field component that allows users to enter and edit date.
 component: true
 links:
-  doc: https://react-day-picker.js.org
+  doc: /docs/packages/duck-calendar
 ---
 
 <ComponentPreview
@@ -20,22 +20,21 @@ See all calendar blocks in the [Blocks Library](/blocks/calendar) page.
 
 ## Philosophy
 
-Calendars are complex accessibility challenges disguised as simple grids. We build on React DayPicker's battle-tested foundation for keyboard navigation, ARIA labels, and locale support, then style it to match the design system. The split between Calendar and CalendarDayButton gives you control over individual day rendering without reimplementing the grid logic.
+Calendars are complex accessibility challenges disguised as simple grids. We own the entire calendar stack — from the headless engine (`@gentleduck/calendar`) to the compound primitives (`@gentleduck/primitives/calendar`) to this styled component. The adapter pattern lets you swap date libraries, the hook layer handles state management, and this component applies Tailwind styling via `data-*` attribute selectors.
 
 ## How It's Built
 
 <MermaidDiagram chart={`graph TD
   Calendar[Calendar]
-  Calendar --> rdp["react-day-picker"]:::external
+  Calendar --> hook["useCalendar"]:::internal
   Calendar --> libs["@gentleduck/libs"]:::internal
-  Calendar --> Button["Button"]:::component
   Calendar --> lucide["lucide-react"]:::external
 
-  rdp --> |"provides"| DayGrid["Day Grid Layout"]
-  rdp --> |"provides"| DateLogic["Date Selection Logic"]
-  rdp --> |"provides"| A11y["ARIA & Keyboard Nav"]
-  Calendar --> |"adds"| CustomDayButton["CalendarDayButton"]
-  Calendar --> |"adds"| Styling["Tailwind Styling"]
+  hook --> adapter["DateAdapter"]:::internal
+  hook --> grid["buildCalendarMonth"]:::internal
+  hook --> selection["selectDay / applySelection"]:::internal
+  hook --> keyboard["useKeyboard"]:::internal
+  hook --> announcer["useAnnouncer"]:::internal
 
   classDef external fill:#818cf8,stroke:#6366f1,color:#fff
   classDef internal fill:#2dd4bf,stroke:#14b8a6,color:#fff
@@ -65,12 +64,12 @@ npx @gentleduck/cli add calendar
 <Step>Install the following dependencies:</Step>
 
 ```bash
-npm install react-day-picker date-fns @gentleduck/libs
+npm install @gentleduck/calendar @gentleduck/libs
 ```
 
 <Step>Add the `Button` component to your project.</Step>
 
-The `Calendar` component uses the [`Button`](/docs/components/button) component. Make sure you have it installed in your project.
+The `Calendar` component uses the [`Button`](/docs/components/button) component's variant styles. Make sure you have it installed in your project.
 
 <Step>Copy and paste the following code into your project.</Step>
 
@@ -103,34 +102,11 @@ return (
 )
 ```
 
-See the [React DayPicker](https://react-day-picker.js.org) documentation for more information.
-
-## About
-
-The `Calendar` component is built on top of [React DayPicker](https://react-day-picker.js.org).
-
-## Customization
-
-See the [React DayPicker](https://react-day-picker.js.org/docs/customization) documentation for more information on how to customize the `Calendar` component.
+See the [@gentleduck/calendar package docs](/docs/packages/duck-calendar) for more information on the headless engine, date adapters, and advanced features.
 
 ## Date Picker
 
 You can use the `<Calendar>` component to build a date picker. See the [Date Picker](/docs/components/date-picker) page for more information.
-
-## Persian / Hijri / Jalali Calendar
-
-To use the Persian calendar, edit `components/ui/calendar.tsx` and replace `react-day-picker` with `react-day-picker/persian`.
-
-```diff showLineNumbers
-- import { DayPicker } from "react-day-picker"
-+ import { DayPicker } from "react-day-picker/persian"
-```
-
-<ComponentPreview
-  name="calendar-2"
-  title="Persian / Hijri / Jalali Calendar"
-  description="A Persian calendar."
-/>
 
 ## Examples
 
@@ -141,14 +117,6 @@ To use the Persian calendar, edit `components/ui/calendar.tsx` and replace `reac
   title="Range Calendar"
   description="A calendar showing the current date and range selection."
   className="**:[.preview]:h-auto lg:**:[.preview]:h-[450px]"
-/>
-
-### Month and Year Selector
-
-<ComponentPreview
-  name="calendar-4"
-  title="Month and Year Selector"
-  description="A calendar with month and year dropdowns."
 />
 
 ### Date of Birth Picker
@@ -181,291 +149,43 @@ This component uses the `chrono-node` library to parse natural language dates.
 
 <ComponentPreview name="calendar-8" description="A date of birth calendar picker integrated with React Hook Form and Zod validation." />
 
-## Upgrade Guide
-
-### Tailwind v4
-
-If you're already using Tailwind v4, you can upgrade to the latest version of the `Calendar` component by running the following command:
-
-```bash
-npx @gentleduck/cli@latest add calendar
-```
-
-When you're prompted to overwrite the existing `Calendar` component, select `Yes`. **If you have made any changes to the `Calendar` component, you will need to merge your changes with the new version.**
-
-This will update the `Calendar` component and `react-day-picker` to the latest version.
-
-Next, follow the [React DayPicker](https://daypicker.dev/upgrading) upgrade guide to upgrade your existing components to the latest version.
-
-#### Installing Blocks
-
-After upgrading the `Calendar` component, you can install the new blocks by running the `@gentleduck/cli@latest add` command.
-
-```bash
-npx @gentleduck/cli@latest add calendar-02
-```
-
-This will install the latest version of the calendar blocks.
-
-### Tailwind v3
-
-If you're using Tailwind v3, you can upgrade to the latest version of the `Calendar` by copying the following code to your `calendar.tsx` file.
-
-
-```tsx showLineNumbers
-// components/ui/calendar.tsx
-
-"use client"
-
-import * as React from "react"
-import {
-  ChevronDownIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-} from "lucide-react"
-import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker"
-
-import { cn } from "@/lib/utils"
-import { Button, buttonVariants } from "@/components/ui/button"
-
-function Calendar({
-  className,
-  classNames,
-  showOutsideDays = true,
-  captionLayout = "label",
-  buttonVariant = "ghost",
-  formatters,
-  components,
-  ...props
-}: React.ComponentProps<typeof DayPicker> & {
-  buttonVariant?: React.ComponentProps<typeof Button>["variant"]
-}) {
-  const defaultClassNames = getDefaultClassNames()
-
-  return (
-    <DayPicker
-      showOutsideDays={showOutsideDays}
-      className={cn(
-        "bg-background group/calendar p-3 [--cell-size:2rem] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
-        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
-        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
-        className
-      )}
-      captionLayout={captionLayout}
-      formatters={{
-        formatMonthDropdown: (date) =>
-          date.toLocaleString("default", { month: "short" }),
-        ...formatters,
-      }}
-      classNames={{
-        root: cn("w-fit", defaultClassNames.root),
-        months: cn(
-          "relative flex flex-col gap-4 md:flex-row",
-          defaultClassNames.months
-        ),
-        month: cn("flex w-full flex-col gap-4", defaultClassNames.month),
-        nav: cn(
-          "absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1",
-          defaultClassNames.nav
-        ),
-        button_previous: cn(
-          buttonVariants({ variant: buttonVariant }),
-          "h-[--cell-size] w-[--cell-size] select-none p-0 aria-disabled:opacity-50",
-          defaultClassNames.button_previous
-        ),
-        button_next: cn(
-          buttonVariants({ variant: buttonVariant }),
-          "h-[--cell-size] w-[--cell-size] select-none p-0 aria-disabled:opacity-50",
-          defaultClassNames.button_next
-        ),
-        month_caption: cn(
-          "flex h-[--cell-size] w-full items-center justify-center px-[--cell-size]",
-          defaultClassNames.month_caption
-        ),
-        dropdowns: cn(
-          "flex h-[--cell-size] w-full items-center justify-center gap-1.5 text-sm font-medium",
-          defaultClassNames.dropdowns
-        ),
-        dropdown_root: cn(
-          "has-focus:border-ring border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] relative rounded-md border",
-          defaultClassNames.dropdown_root
-        ),
-        dropdown: cn("absolute inset-0 opacity-0", defaultClassNames.dropdown),
-        caption_label: cn(
-          "select-none font-medium",
-          captionLayout === "label"
-            ? "text-sm"
-            : "[&>svg]:text-muted-foreground flex h-8 items-center gap-1 rounded-md pl-2 pr-1 text-sm [&>svg]:size-3.5",
-          defaultClassNames.caption_label
-        ),
-        table: "w-full border-collapse",
-        weekdays: cn("flex", defaultClassNames.weekdays),
-        weekday: cn(
-          "text-muted-foreground flex-1 select-none rounded-md text-[0.8rem] font-normal",
-          defaultClassNames.weekday
-        ),
-        week: cn("mt-2 flex w-full", defaultClassNames.week),
-        week_number_header: cn(
-          "w-[--cell-size] select-none",
-          defaultClassNames.week_number_header
-        ),
-        week_number: cn(
-          "text-muted-foreground select-none text-[0.8rem]",
-          defaultClassNames.week_number
-        ),
-        day: cn(
-          "group/day relative aspect-square h-full w-full select-none p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md",
-          defaultClassNames.day
-        ),
-        range_start: cn(
-          "bg-accent rounded-l-md",
-          defaultClassNames.range_start
-        ),
-        range_middle: cn("rounded-none", defaultClassNames.range_middle),
-        range_end: cn("bg-accent rounded-r-md", defaultClassNames.range_end),
-        today: cn(
-          "bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none",
-          defaultClassNames.today
-        ),
-        outside: cn(
-          "text-muted-foreground aria-selected:text-muted-foreground",
-          defaultClassNames.outside
-        ),
-        disabled: cn(
-          "text-muted-foreground opacity-50",
-          defaultClassNames.disabled
-        ),
-        hidden: cn("invisible", defaultClassNames.hidden),
-        ...classNames,
-      }}
-      components={{
-        Root: ({ className, rootRef, ...props }) => {
-          return (
-            <div
-              data-slot="calendar"
-              ref={rootRef}
-              className={cn(className)}
-              {...props}
-            />
-          )
-        },
-        Chevron: ({ className, orientation, ...props }) => {
-          if (orientation === "left") {
-            return (
-              <ChevronLeftIcon className={cn("size-4", className)} {...props} />
-            )
-          }
-
-          if (orientation === "right") {
-            return (
-              <ChevronRightIcon
-                className={cn("size-4", className)}
-                {...props}
-              />
-            )
-          }
-
-          return (
-            <ChevronDownIcon className={cn("size-4", className)} {...props} />
-          )
-        },
-        DayButton: CalendarDayButton,
-        WeekNumber: ({ children, ...props }) => {
-          return (
-            <td {...props}>
-              <div className="flex size-[--cell-size] items-center justify-center text-center">
-                {children}
-              </div>
-            </td>
-          )
-        },
-        ...components,
-      }}
-      {...props}
-    />
-  )
-}
-
-function CalendarDayButton({
-  className,
-  day,
-  modifiers,
-  ...props
-}: React.ComponentProps<typeof DayButton>) {
-  const defaultClassNames = getDefaultClassNames()
-
-  const ref = React.useRef<HTMLButtonElement>(null)
-  React.useEffect(() => {
-    if (modifiers.focused) ref.current?.focus()
-  }, [modifiers.focused])
-
-  return (
-    <Button
-      ref={ref}
-      variant="ghost"
-      size="icon"
-      data-day={day.date.toLocaleDateString()}
-      data-selected-single={
-        modifiers.selected &&
-        !modifiers.range_start &&
-        !modifiers.range_end &&
-        !modifiers.range_middle
-      }
-      data-range-start={modifiers.range_start}
-      data-range-end={modifiers.range_end}
-      data-range-middle={modifiers.range_middle}
-      className={cn(
-        "data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 flex aspect-square h-auto w-full min-w-[--cell-size] flex-col gap-1 font-normal leading-none data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] [&>span]:text-xs [&>span]:opacity-70",
-        defaultClassNames.day,
-        className
-      )}
-      {...props}
-    />
-  )
-}
-
-export { Calendar, CalendarDayButton }
-```
-
-
-**If you have made any changes to the `Calendar` component, you will need to merge your changes with the new version.**
-
-Then follow the [React DayPicker](https://daypicker.dev/upgrading) upgrade guide to upgrade your dependencies and existing components to the latest version.
-
-#### Installing Blocks
-
-After upgrading the `Calendar` component, you can install the new blocks by running the `@gentleduck/cli@latest add` command.
-
-```bash
-npx @gentleduck/cli@latest add calendar-02
-```
-
-This will install the latest version of the calendar blocks.
-
 ## API Reference
 
 ### Calendar
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
-| `dir` | `'ltr' \| 'rtl'` | -- | Text direction override. Resolved via `useDirection` (`dir` prop -> `DirectionProvider` -> `'ltr'`). |
-| `buttonVariant` | `React.ComponentProps<typeof Button>['variant']` | `'ghost'` | Variant style for the calendar's navigation buttons |
-| `className` | `string` | -- | Additional class names for the root calendar container |
-| `classNames` | `Partial<ReturnType<typeof getDefaultClassNames>>` | -- | Overrides for internal DayPicker class names |
-| `showOutsideDays` | `boolean` | `true` | Whether to show days from the previous/next month in the current month view |
-| `captionLayout` | `'buttons' \| 'dropdown' \| 'label'` | `'label'` | Layout for the month/year caption |
-| `formatters` | `DayPicker['formatters']` | -- | Custom formatting functions for dates and labels |
-| `components` | `DayPicker['components']` | -- | Custom component overrides for internal DayPicker parts |
-| `...props` | `React.ComponentProps<typeof DayPicker>` | -- | Additional standard component props. |
+| `mode` | `'single' \| 'range' \| 'multi'` | `'single'` | Selection mode |
+| `selected` | `Date \| DateRange<Date> \| Date[] \| null` | -- | Controlled selection value |
+| `onSelect` | `(value) => void` | -- | Called when the selection changes |
+| `disabled` | `Date[] \| ((date: Date) => boolean)` | -- | Dates that cannot be selected |
+| `defaultMonth` | `Date` | -- | Default month to display (uncontrolled) |
+| `month` | `Date` | -- | Controlled displayed month |
+| `onMonthChange` | `(month: Date) => void` | -- | Called when the displayed month changes |
+| `showOutsideDays` | `boolean` | `true` | Show days from adjacent months |
+| `fixedWeeks` | `boolean` | `false` | Always show 6 weeks |
+| `numberOfMonths` | `number` | `1` | How many months to show side by side |
+| `locale` | `string` | -- | BCP 47 locale tag (e.g. `'ar-SA'`, `'ja-JP'`) |
+| `dir` | `'ltr' \| 'rtl'` | -- | Text direction override |
+| `fromDate` | `Date` | -- | Earliest selectable date |
+| `toDate` | `Date` | -- | Latest selectable date |
+| `className` | `string` | -- | Additional CSS classes for the root container |
 
-### CalendarDayButton
+### Data Attributes
 
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `day` | `CalendarDay` | (required) | The day object for this cell from `react-day-picker` |
-| `modifiers` | `Modifiers` | (required) | Selection and state flags for the day (e.g., `selected`, `range_start`, `range_end`) |
-| `className` | `string` | -- | Additional CSS classes for styling the day button |
-| `...props` | `React.ComponentProps<typeof DayButton>` | -- | Additional standard component props. |
+The calendar uses `data-*` attributes on day cells for styling. Target these in your CSS:
+
+| Attribute | When Present |
+| --- | --- |
+| `data-selected="true"` | Day is selected |
+| `data-today="true"` | Day is today |
+| `data-disabled="true"` | Day is disabled |
+| `data-outside-month="true"` | Day is from an adjacent month |
+| `data-in-range="true"` | Day is between range start and end |
+| `data-range-start="true"` | Day is the start of a range |
+| `data-range-end="true"` | Day is the end of a range |
+| `data-focused="true"` | Day has keyboard focus |
+| `data-weekend="true"` | Day is Saturday or Sunday |
 
 ## RTL Support
 

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar.mdx
@@ -1,0 +1,306 @@
+---
+title: duck-calendar
+description: Headless, framework-agnostic calendar engine with date adapter pattern, React hooks, and compound components.
+---
+
+## Philosophy
+
+`@gentleduck/calendar` is a headless calendar engine that owns the entire date-picking stack:
+
+1. **Core** — Pure functions for grid building, selection logic, and navigation. No React, no state, no side effects.
+2. **Adapter** — A `DateAdapter<TDate>` interface that abstracts date operations. Ship with a zero-dependency `NativeAdapter` for `Date`. Plug in dayjs, date-fns, or Temporal when needed.
+3. **React hooks** — `useCalendar`, `useTimePicker`, `useDateTime` manage state and produce prop getters you spread onto your elements.
+4. **Compound components** — Available in `@gentleduck/primitives/calendar` for consumers who want convenience. Optional — hooks are first-class.
+
+## Installation
+
+```bash
+npm install @gentleduck/calendar
+```
+
+For compound components:
+
+```bash
+npm install @gentleduck/primitives
+```
+
+## Quick Start
+
+### Using the hook directly
+
+```tsx showLineNumbers
+import { NativeAdapter, useCalendar } from '@gentleduck/calendar'
+
+const adapter = new NativeAdapter()
+
+function MyCalendar() {
+  const { state, getDayProps, getGridProps, getHeaderProps, getNavProps } = useCalendar({
+    adapter,
+    mode: 'single',
+  })
+
+  return (
+    <div>
+      <div {...getHeaderProps()}>
+        {adapter.format(state.month, { month: 'long', year: 'numeric' })}
+      </div>
+      <button {...getNavProps('prev')}>←</button>
+      <button {...getNavProps('next')}>→</button>
+      <div {...getGridProps()}>
+        {state.weeks.map(week =>
+          week.days.map(day => (
+            <button key={day.date.getTime()} {...getDayProps(day)}>
+              {day.date.getDate()}
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+### Using compound components
+
+```tsx showLineNumbers
+import { NativeAdapter } from '@gentleduck/calendar'
+import * as CalendarPrimitive from '@gentleduck/primitives/calendar'
+
+const adapter = new NativeAdapter()
+
+function MyCalendar() {
+  return (
+    <CalendarPrimitive.Root adapter={adapter} mode="single">
+      <CalendarPrimitive.Header />
+      <CalendarPrimitive.Nav />
+      <CalendarPrimitive.Grid>
+        <CalendarPrimitive.Weekdays />
+        {/* Render day cells using CalendarPrimitive.Day */}
+      </CalendarPrimitive.Grid>
+    </CalendarPrimitive.Root>
+  )
+}
+```
+
+## Date Adapter
+
+The `DateAdapter<TDate>` interface abstracts all date operations. The engine never calls `new Date()` or `date.getMonth()` directly — everything goes through the adapter.
+
+### Built-in: NativeAdapter
+
+Zero dependencies. Uses `Date` + `Intl.DateTimeFormat`.
+
+```tsx
+import { NativeAdapter } from '@gentleduck/calendar'
+const adapter = new NativeAdapter()
+```
+
+### Writing a Custom Adapter
+
+Implement the `DateAdapter<TDate>` interface for your preferred date library:
+
+```tsx showLineNumbers
+import type { DateAdapter } from '@gentleduck/calendar'
+import dayjs, { type Dayjs } from 'dayjs'
+
+const dayjsAdapter: DateAdapter<Dayjs> = {
+  today: () => dayjs().startOf('day'),
+  create: (y, m, d) => dayjs().year(y).month(m).date(d).startOf('day'),
+  isValid: (d) => d.isValid(),
+  isSameDay: (a, b) => a.isSame(b, 'day'),
+  isSameMonth: (a, b) => a.isSame(b, 'month'),
+  isBefore: (a, b) => a.isBefore(b),
+  isAfter: (a, b) => a.isAfter(b),
+  startOfMonth: (d) => d.startOf('month'),
+  endOfMonth: (d) => d.endOf('month'),
+  startOfWeek: (d, weekStart) => {
+    const diff = (d.day() - weekStart + 7) % 7
+    return d.subtract(diff, 'day')
+  },
+  addDays: (d, n) => d.add(n, 'day'),
+  addMonths: (d, n) => d.add(n, 'month'),
+  addYears: (d, n) => d.add(n, 'year'),
+  getYear: (d) => d.year(),
+  getMonth: (d) => d.month(),
+  getDate: (d) => d.date(),
+  getDayOfWeek: (d) => d.day() as any,
+  toDate: (d) => d.toDate(),
+  fromDate: (d) => dayjs(d).startOf('day'),
+  format: (d, opts, locale) => new Intl.DateTimeFormat(locale, opts).format(d.toDate()),
+  getHours: (d) => d.hour(),
+  getMinutes: (d) => d.minute(),
+  getSeconds: (d) => d.second(),
+  setTime: (d, h, m, s) => d.hour(h).minute(m).second(s ?? 0),
+}
+```
+
+## Selection Modes
+
+### Single
+
+```tsx
+const { state } = useCalendar({ adapter, mode: 'single' })
+// state.value: Date | null
+```
+
+### Range
+
+```tsx
+const { state } = useCalendar({ adapter, mode: 'range' })
+// state.value: { from: Date, to: Date | null } | null
+```
+
+### Multi
+
+```tsx
+const { state } = useCalendar({ adapter, mode: 'multi' })
+// state.value: Date[]
+```
+
+## Multi-Month
+
+```tsx
+const { state } = useCalendar({
+  adapter,
+  mode: 'range',
+  numberOfMonths: 2,
+})
+
+// state.months — array of CalendarMonth objects
+// state.weeks — first month's weeks (backward compat)
+```
+
+## Time Picker
+
+```tsx showLineNumbers
+import { useTimePicker } from '@gentleduck/calendar'
+
+function MyTimePicker() {
+  const { state, getFieldProps } = useTimePicker({
+    hourCycle: '12',
+    showSeconds: true,
+  })
+
+  return (
+    <div>
+      <input {...getFieldProps('hour')} />
+      <span>:</span>
+      <input {...getFieldProps('minute')} />
+      <span>:</span>
+      <input {...getFieldProps('second')} />
+      <button {...getFieldProps('ampm')}>{state.displayAmPm}</button>
+    </div>
+  )
+}
+```
+
+## DateTime Picker
+
+```tsx showLineNumbers
+import { NativeAdapter, useDateTime } from '@gentleduck/calendar'
+
+const adapter = new NativeAdapter()
+
+function MyDateTimePicker() {
+  const { calendar, timePicker, state } = useDateTime({
+    adapter,
+    defaultValue: new Date(),
+    hourCycle: '12',
+  })
+
+  // calendar — full UseCalendarReturn (state, actions, prop getters)
+  // timePicker — full UseTimePickerReturn (state, actions, getFieldProps)
+  // state.value — combined Date with both date and time
+}
+```
+
+## Keyboard Navigation
+
+| Key | Action |
+| --- | --- |
+| `ArrowLeft` / `ArrowRight` | Move focus ±1 day |
+| `ArrowUp` / `ArrowDown` | Move focus ±1 week |
+| `PageUp` / `PageDown` | Move focus ±1 month |
+| `Shift+PageUp` / `Shift+PageDown` | Move focus ±1 year |
+| `Home` / `End` | Move to start/end of week |
+| `Enter` / `Space` | Select focused date |
+| `Escape` | Dismiss (calls `onDismiss`) |
+
+Focus auto-advances the displayed month when crossing boundaries.
+
+## Accessibility
+
+- `role="grid"` on the grid container with `aria-roledescription="calendar"`
+- `role="gridcell"` on each day with full `aria-label` (e.g. "Saturday, March 14, 2026")
+- `aria-selected`, `aria-disabled`, `aria-current="date"` on days
+- `aria-live="polite"` announcer for month navigation and selection changes
+- Roving `tabIndex` — only the focused date has `tabIndex=0`
+- `role="navigation"` on nav wrapper
+
+## Styling with Data Attributes
+
+The calendar outputs `data-*` attributes on every element. Style with Tailwind:
+
+```css
+/* Selected day */
+[data-selected="true"] { @apply bg-primary text-primary-foreground; }
+
+/* Today */
+[data-today="true"] { @apply bg-accent text-accent-foreground; }
+
+/* Disabled */
+[data-disabled="true"] { @apply opacity-50 cursor-not-allowed; }
+
+/* Range */
+[data-range-start="true"] { @apply rounded-l-md bg-primary; }
+[data-in-range="true"] { @apply bg-accent; }
+[data-range-end="true"] { @apply rounded-r-md bg-primary; }
+
+/* Outside month */
+[data-outside-month="true"] { @apply text-muted-foreground; }
+
+/* Focus */
+[data-focused="true"] { @apply ring-2 ring-ring; }
+```
+
+## API Reference
+
+### Core Functions
+
+| Function | Signature | Description |
+| --- | --- | --- |
+| `buildCalendarMonth` | `(adapter, date, config) => CalendarMonth` | Build a month grid |
+| `buildMultiMonth` | `(adapter, date, count, config) => CalendarMonth[]` | Build multiple consecutive month grids |
+| `buildCalendarYear` | `(adapter, date, locale?) => YearEntry[]` | Build 12-month picker entries |
+| `buildDecadeView` | `(adapter, date) => DecadeEntry[]` | Build decade picker entries |
+| `selectDay` | `(adapter, mode, current, date) => CalendarValue` | Compute new selection value |
+| `applySelection` | `(weeks, adapter, mode, value, constraints) => CalendarWeek[]` | Decorate weeks with selection flags |
+| `navigate` | `(adapter, date, direction, unit) => TDate` | Navigate to next/prev month/year/decade |
+| `canNavigate` | `(adapter, date, direction, unit, constraints?) => boolean` | Check if navigation is within bounds |
+
+### React Hooks
+
+| Hook | Description |
+| --- | --- |
+| `useCalendar(config)` | Main calendar hook — state, actions, prop getters |
+| `useTimePicker(config)` | Time picker hook — spinbutton fields, keyboard input |
+| `useDateTime(config)` | Combined date + time — composes useCalendar + useTimePicker |
+| `useKeyboard(config)` | Keyboard navigation for the day grid |
+| `useAnnouncer()` | Screen reader announcements |
+
+### Types
+
+| Type | Description |
+| --- | --- |
+| `DateAdapter<TDate>` | Interface for pluggable date backends |
+| `CalendarConfig<TDate, M>` | Full calendar configuration |
+| `CalendarValue<TDate, M>` | Conditional type resolving per selection mode |
+| `CalendarDay<TDate>` | Day cell with selection/state flags |
+| `CalendarWeek<TDate>` | Week with weekNumber + 7 days |
+| `CalendarMonth<TDate>` | Month grid with weeks |
+| `SelectionMode` | `'single' \| 'range' \| 'multi'` |
+| `DateRange<TDate>` | `{ from: TDate, to: TDate \| null }` |
+| `TimeValue` | `{ hour, minute, second? }` |
+| `TimeField` | `'hour' \| 'minute' \| 'second' \| 'ampm'` |
+| `HourCycle` | `'12' \| '24'` |
+| `ViewMode` | `'days' \| 'months' \| 'years'` |

--- a/packages/duck-calendar/PLAN.md
+++ b/packages/duck-calendar/PLAN.md
@@ -1,78 +1,19 @@
-# duck-calendar: Type-Level Tests and Type Inference Validation
+# duck-calendar: Documentation, Examples, and API Reference
 
-Issue #310. Verify that the generic type system works correctly at compile time using vitest's `expectTypeOf`.
+Issue #312. Comprehensive documentation for the duck-calendar package.
 
-> Depends on: #304–#309 — all complete.
+> Depends on: #304–#311 — all complete.
 
 ## What was done
 
-Added `src/__test__/types.test-d.ts` with 44 type-level assertions covering:
+### Updated component doc
+- Replaced react-day-picker references with @gentleduck/calendar
+- Updated architecture diagram, installation, API reference, data attributes table
 
-### CalendarValue conditional type
-- `'single'` → `TDate | null`
-- `'range'` → `DateRange<TDate> | null`
-- `'multi'` → `TDate[]`
-- Works with custom `TDate` types (e.g. `DayjsDate`)
+### Created package doc
+- Philosophy, quick start (hook + compound), date adapter guide
+- Selection modes, multi-month, time picker, datetime picker
+- Keyboard navigation, accessibility, styling guide, full API reference
 
-### DateAdapter generic flow
-- `NativeAdapter` implements `DateAdapter<Date>`
-- All adapter methods accept/return the correct `TDate`
-- Time accessors return numbers
-- Boolean methods return boolean
-- Custom `TDate` types propagate correctly through the interface
-
-### CalendarConfig type
-- `selected` type matches mode
-- `onSelect` callback parameter matches mode
-- `disabled` accepts array or predicate
-- `fromDate`/`toDate` are optional `TDate`
-
-### UseCalendarReturn type
-- `state.value` type resolves fully per mode (no unresolved conditional)
-- State shape: month, focusedDate, viewMode, weeks, months, weekdays, canGoNext, canGoPrevious
-- Actions have correct function signatures
-- Prop getters return DayProps, GridProps, NavProps, HeaderProps
-- `getDayProps` accepts `CalendarDay<TDate>`
-
-### DayProps / GridProps types
-- Correct ARIA attribute types (literal strings)
-- data-* attribute types (`'true' | undefined`)
-- Event handler types
-
-### Time types
-- `TimeValue` has hour/minute required, second optional
-- `TimeField` is the correct union
-- `HourCycle` is `'12' | '24'`
-- `UseTimePickerReturn` state and `TimeFieldProps` shapes
-
-### UseDateTimeReturn type
-- Has calendar and timePicker sub-returns
-- `state.value` is `TDate | null`
-- `actions.setValue` accepts `TDate`
-
-### Pure function return types
-- `selectDay` returns `CalendarValue` matching mode
-- `buildCalendarMonth` returns `CalendarMonth<TDate>`
-- `buildMultiMonth` returns `CalendarMonth<TDate>[]`
-- `navigate` returns `TDate`
-- `canNavigate` returns `boolean`
-- `clampTime` returns `TimeValue`
-- `parseTimeInput` returns `number | null`
-
-## Configuration
-
-Enabled vitest typecheck in `vitest.config.ts`:
-```ts
-typecheck: {
-  enabled: true,
-  include: ['src/**/*.test-d.ts'],
-}
-```
-
-## Verification
-
-```bash
-npx turbo run check-types build test --filter=@gentleduck/calendar --force
-```
-
-408 tests passing (364 runtime + 44 type-level). Zero type errors.
+### Updated sidebar config
+- Added "Gentleduck Calendar" entry in Core Packages with `label: 'new'`


### PR DESCRIPTION
## Summary

- Add 22+ MDX documentation pages for @gentleduck/calendar:
  - Overview, Getting Started
  - Guides: Date Adapters, Styling, Accessibility
  - API Reference: useCalendar, useTimePicker, useDateTime, Grid, Selection, Navigation
  - Course (8 lessons): Introduction through Performance
- Add primitives Calendar API documentation
- Update component docs (calendar.mdx, date-picker.mdx) with migration callout
- Add professional benchmark SVG charts (6 charts comparing bundle size, deps, features, performance)
- Add comparison pages (vs react-day-picker, vs shadcn)
- SEO: JSON-LD structured data, meta keywords, robots.txt

## Test plan

- [ ] All docs pages render in dev server without errors
- [ ] Code examples in docs are syntactically correct
- [ ] Benchmark SVGs display correctly
- [ ] Navigation sidebar shows all duck-calendar pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the calendar package, including setup instructions, quick-start examples, and full API reference
  * Updated calendar component guide with new prop interface, data attributes for styling, and available selection modes
  * Added new navigation entry in documentation sidebar for calendar package

<!-- end of auto-generated comment: release notes by coderabbit.ai -->