### PR TITLE
docs(shortcut): rewrite README to match project style

### DIFF
--- a/packages/duck-shortcut/README.md
+++ b/packages/duck-shortcut/README.md
@@ -1,173 +1,54 @@
-<p align="center">
-  <img src="./public/logo.png" alt="Duck UI Logo" width="200"/>
-</p>
+# @gentleduck/shortcut
 
-# `@gentleduck/shortcut`
+> **Deprecated** -- use [`@gentleduck/vim`](../duck-vim) instead.
 
-A lightweight React component for easily binding and handling keyboard shortcuts in your React applications.
+Keyboard shortcut hook for React.
 
-## Features
-
-- **Easy Integration**: Integrate keyboard shortcuts into your React application effortlessly. Simply use the `useDuckShortcut` hook and pass the required props to handle key combinations or sequences.
-- **Support for Key Combinations**: Handle key combinations like `Ctrl+S` or `Command+K` with ease. The component can take a single string or an array of key combinations.
-- **Support for Key Sequences**: React to key sequences such as `Up Up Down Down Left Right B A Enter`. You can define these sequences as strings or arrays.
-- **Mixed Key Combinations and Sequences**: Combine both key combinations and sequences to define more complex shortcuts.
-- **Global Keyboard Event Listener**: The component adds a global keyboard event listener that works anywhere in the component tree without preventing events from bubbling or capturing.
-- **TypeScript Support**: Fully implemented in TypeScript with type definitions, ensuring a smooth development experience with type safety.
-- **Case Insensitivity**: The component handles key shortcuts in a case-insensitive manner, so you don't need to worry about key case.
-- **No Conflict with Other Components**: Use multiple instances of `useDuckShortcut` for different shortcuts without conflicts.
-
-## Installation
-
-To install the toolkit, use npm or yarn:
+## Quick start
 
 ```bash
 npm install @gentleduck/shortcut
-# or
-yarn add @gentleduck/shortcut
 ```
-
-## Usage
-
-Here's a quick guide on how to use the library:
 
 ```tsx
 import { useDuckShortcut } from '@gentleduck/shortcut'
 
-const App = () => {
+function App() {
   useDuckShortcut({
-    keys: ['ctrl+s'], // Key combinations or sequences
-    onKeysPressed: () => {
-      console.log('Ctrl+S was pressed!')
-    },
+    keys: ['ctrl+s'],
+    onKeysPressed: () => console.log('Ctrl+S pressed'),
   })
 
-  return <div>Press Ctrl+S to trigger the shortcut</div>
+  return <div>Press Ctrl+S</div>
 }
 ```
 
-### Handling Multiple Shortcuts
+## Features
 
-You can handle multiple key combinations or sequences by passing them as an array:
+- Key combinations (`ctrl+s`, `command+k`)
+- Key sequences (`Up Up Down Down Left Right B A Enter`)
+- Mixed combinations and sequences in one binding
+- Global listener -- no event capture conflicts
+- Case-insensitive key names
+- Multiple instances without conflicts
 
-```typescript
-import { useDuckShortcut } from '@gentleduck/shortcut'
-const App = () => {
-  useDuckShortcut({
-    keys: ['ctrl+s', 'command+k'], // Multiple shortcuts
-    onKeysPressed: () => {
-      console.log('Ctrl+S or Command+K was pressed!')
-    },
-  })
-  return <div>Press Ctrl+S or Command+K to trigger the shortcut</div>
-}
-```
-
-## API Reference
-
-Here's an API reference for `@gentleduck/shortcut` in MDX format, detailing the types and usage of the `useDuckShortcut` hook:
-
-## `useDuckShortcut`
-
-The `useDuckShortcut` hook allows you to bind keyboard shortcuts to callback functions in your React components.
-
-### Importing
-
-```jsx
-import { useDuckShortcut } from '@gentleduck/shortcut'
-```
-
-### Usage
-
-```jsx
-useDuckShortcut({
-  keys: /* Key combinations or sequences */,
-  onKeysPressed: /* Callback function */,
-});
-```
-
-### Parameters
-
-#### `keys`
-
-- **Type**: `string | string[]`
-- **Description**: Defines the keyboard shortcuts to listen for. You can specify key combinations (e.g., `'ctrl+s'`, `'command+k'`) or key sequences (e.g., `'Up Up Down Down Left Right B A Enter'`).
-
-##### Example
-
-```jsx
-keys: 'ctrl+s'
-```
-
-or
-
-```jsx
-keys: ['ctrl+s', 'command+k']
-```
-
-or
-
-```jsx
-keys: 'Up Up Down Down Left Right B A Enter'
-```
-
-#### `onKeysPressed`
-
-- **Type**: `() => void`
-- **Description**: Callback function that gets called when the specified key combinations or sequences are pressed.
-
-##### Example
-
-```jsx
-onKeysPressed: () => {
-  console.log('Shortcut triggered!')
-}
-```
-
-### Example
-
-```jsx
-import { useDuckShortcut } from '@gentleduck/shortcut'
-
-const App = () => {
-  useDuckShortcut({
-    keys: ['ctrl+s', 'command+k'], // Define your shortcuts
-    onKeysPressed: () => {
-      // Callback when shortcuts are pressed
-      console.log('Shortcut triggered!')
-    },
-  })
-
-  return <div>Press Ctrl+S or Command+K</div>
-}
-```
-
-### Notes
-
-- **Key Combinations**: These are key presses that need to happen simultaneously (e.g., `'ctrl+s'`, `'command+shift+P'`).
-- **Key Sequences**: These are key presses that need to happen in sequence (e.g., `'Up Up Down Down Left Right B A Enter'`).
-- **Case Sensitivity**: Key names are case-insensitive.
-
-## Type Definitions
-
-### `DuckShortcutProps`
-
-```typescript
-interface DuckShortcutProps {
-  keys: string | string[] // Key combinations or sequences
-  onKeysPressed: () => void // Callback when shortcuts are pressed
-}
-```
+## API
 
 ### `useDuckShortcut`
 
 ```typescript
+interface DuckShortcutProps {
+  keys: string | string[]
+  onKeysPressed: () => void
+}
+
 declare function useDuckShortcut(props: DuckShortcutProps): void
 ```
 
-## Contributing
-
-Contributions are welcome! Please open issues and pull requests on the [GitHub repository](https://github.com/gentleeduck/duck-ui).
+| Prop | Type | Description |
+| --- | --- | --- |
+| `keys` | `string \| string[]` | Shortcut bindings -- combinations (`'ctrl+s'`) or sequences (`'Up Up Down Down'`) |
+| `onKeysPressed` | `() => void` | Called when any listed shortcut fires |
 
 ## License
 


### PR DESCRIPTION
## Summary

- Rewrote packages/duck-shortcut/README.md to match the code-first style of sibling READMEs (duck-vim, duck-hooks)
- Added deprecation notice pointing to @gentleduck/vim
- Reduced from 175 lines to 56 lines while keeping API docs accurate

## Test plan

- [x] Markdown-only change, no runtime impact
- [x] API docs remain accurate (useDuckShortcut, keys, onKeysPressed)
- [x] Deprecation notice links correctly