### PR TITLE
fix: replace boilerplate SECURITY.md in 13 packages

### DIFF
--- a/packages/duck-benchmark/SECURITY.md
+++ b/packages/duck-benchmark/SECURITY.md
@@ -1,21 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-cli/SECURITY.md
+++ b/packages/duck-cli/SECURITY.md
@@ -1,18 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.0.0   | :white_check_mark: |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-emoji/SECURITY.md
+++ b/packages/duck-emoji/SECURITY.md
@@ -1,18 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.0.0   | :red_check_mark: |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-extension/SECURITY.md
+++ b/packages/duck-extension/SECURITY.md
@@ -1,18 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.0.0   | :red_check_mark: |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-hooks/SECURITY.md
+++ b/packages/duck-hooks/SECURITY.md
@@ -1,19 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.1   | :white_check_mark: |
-| 0.1.0   | :white_check_mark: |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-lazy/SECURITY.md
+++ b/packages/duck-lazy/SECURITY.md
@@ -1,20 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.2.5   | :white_check_mark: |
-| 1.2.2   | :white_check_mark: |
-| 1.2.0   | :white_check_mark: |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-libs/SECURITY.md
+++ b/packages/duck-libs/SECURITY.md
@@ -1,19 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.5   | :white_check_mark: |
-| 0.1.0   | :white_check_mark: |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-motion/SECURITY.md
+++ b/packages/duck-motion/SECURITY.md
@@ -1,19 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.2   | :white_check_mark: |
-| 0.1.0   | :white_check_mark: |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-primitives/SECURITY.md
+++ b/packages/duck-primitives/SECURITY.md
@@ -1,20 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.24   | :white_check_mark: |
-| 0.1.2   | :white_check_mark: |
-| 0.1.0   | :white_check_mark: |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-shortcut/SECURITY.md
+++ b/packages/duck-shortcut/SECURITY.md
@@ -1,21 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-state/SECURITY.md
+++ b/packages/duck-state/SECURITY.md
@@ -1,21 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-variants/SECURITY.md
+++ b/packages/duck-variants/SECURITY.md
@@ -1,20 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.12  | :white_check_mark: |
-| 0.1.6   | :white_check_mark: |
-| 0.1.5   | :white_check_mark: |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.

--- a/packages/duck-vim/SECURITY.md
+++ b/packages/duck-vim/SECURITY.md
@@ -1,20 +1,19 @@
 # Security Policy
 
 ## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.7   | :white_check_mark: |
-| 0.1.5   | :white_check_mark: |
-| 0.1.0   | :white_check_mark: |
+We provide security updates for the latest major release of gentleduck/ui.  
+Older versions may not receive patches.
 
 ## Reporting a Vulnerability
+⚠️ **Please do not disclose security issues publicly.**  
+If you discover a vulnerability in gentleduck/ui:
 
-Use this section to tell people how to report a vulnerability.
+1. Report it privately by emailing: **security@gentleduck.org**
+2. Include a detailed description of the vulnerability and how to reproduce it.
+3. We will confirm receipt within **48 hours** and provide a timeline for a fix.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Responsible Disclosure
+We ask security researchers to give us **90 days** to address issues before public disclosure.  
+We will credit you in release notes unless you prefer to remain anonymous.
+
+Thank you for helping keep gentleduck/ui secure.


### PR DESCRIPTION
## Summary

- Replaced GitHub template placeholder text in 13 package SECURITY.md files with the actual project security policy
- All 13 files now match the root SECURITY.md (reporting email, disclosure timeline, responsible disclosure terms)
- Removed stale version tables with outdated version numbers

## Affected packages

duck-vim, duck-shortcut, duck-state, duck-variants, duck-primitives, duck-lazy, duck-libs, duck-motion, duck-hooks, duck-extension, duck-emoji, duck-cli, duck-benchmark

## Test plan

- [x] All 13 files match root SECURITY.md
- [x] Markdown-only change, no runtime impact