### PR TITLE
fix: replace -- with single-dash in package MDX docs

### DIFF
--- a/apps/duck-ui-docs/content/docs/packages/duck-lazy.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-lazy.mdx
@@ -61,8 +61,8 @@ function MyComponent() {
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
-| `options` | `IntersectionObserverInit` | -- | IntersectionObserver options (`rootMargin`, `threshold`) |
-| `children` | `React.ReactNode` | -- | The lazy-loaded content (required) |
+| `options` | `IntersectionObserverInit` | - | IntersectionObserver options (`rootMargin`, `threshold`) |
+| `children` | `React.ReactNode` | - | The lazy-loaded content (required) |
 
 ---
 
@@ -94,12 +94,12 @@ function MyImageComponent() {
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
 | `src` | `string` | (required) | URL of the image |
-| `placeholder` | `string` | -- | Placeholder URL while loading |
+| `placeholder` | `string` | - | Placeholder URL while loading |
 | `alt` | `string` | (required) | Accessible description |
 | `width` | `number` | `200` | Image width |
 | `height` | `number` | `200` | Image height |
 | `options` | `IntersectionObserverInit` | `{ rootMargin: '200px', threshold: 0.1 }` | IntersectionObserver options |
-| `nextImage` | `boolean` | -- | Enables Next.js `next/image` optimization |
+| `nextImage` | `boolean` | - | Enables Next.js `next/image` optimization |
 
 ---
 

--- a/apps/duck-ui-docs/content/docs/packages/duck-template.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-template.mdx
@@ -1,6 +1,6 @@
 ---
 title: "gentleduck/template"
-description: Fast, customizable Rust-powered project scaffolding -- because smart devs don't start from scratch.
+description: Fast, customizable Rust-powered project scaffolding  -  because smart devs don't start from scratch.
 ---
 
 <Callout icon={<Zap />}>

--- a/apps/duck-ui-docs/content/docs/packages/duck-vim/api/react.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-vim/api/react.mdx
@@ -309,7 +309,7 @@ The recorder automatically prevents default behavior and stops propagation while
 | `useKeyBind` | Single binding | No |
 | `useKeySequence` | Multi-step sequence | Yes |
 | `useKeyCommands` | Bulk registration | Via Registry (e.g. `'g+d'`) |
-| `useKeyRecorder` | Settings UI | -- |
+| `useKeyRecorder` | Settings UI | - |
 
 <Callout icon={<Lightbulb />}>
 

--- a/apps/duck-ui-docs/content/docs/packages/duck-vim/course/04-react.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-vim/course/04-react.mdx
@@ -42,7 +42,7 @@ duck-vim's React layer wraps the core system in a context provider and exposes h
 | --- | --- | --- | --- |
 | `debug` | `boolean` | `false` | Log key events and matches to console |
 | `timeoutMs` | `number` | `600` | Timeout for multi-key sequences |
-| `defaultOptions` | `Partial<KeyBindOptions>` | -- | Default options for all bindings |
+| `defaultOptions` | `Partial<KeyBindOptions>` | - | Default options for all bindings |
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace `--` (double dash) with `-` (single dash) in MDX table cells across duck-lazy, duck-vim, and duck-template docs
- Replace `--` with `  -  ` (spaced single dash) in duck-template frontmatter prose
- Correctly skips code blocks (e.g., CLI `--` argument separator in recipes.mdx)

## Files changed
- `apps/duck-ui-docs/content/docs/packages/duck-lazy.mdx` (4 table cells)
- `apps/duck-ui-docs/content/docs/packages/duck-template.mdx` (1 frontmatter line)
- `apps/duck-ui-docs/content/docs/packages/duck-vim/api/react.mdx` (1 table cell)
- `apps/duck-ui-docs/content/docs/packages/duck-vim/course/04-react.mdx` (1 table cell)

## Test plan
- [x] Verified no `--` remains outside code blocks in target files
- [x] Confirmed code block content (CLI args) was preserved unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation table formatting to standardize default value indicators across multiple package guides for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->