### PR TITLE
docs(duck-calendar): replace double-dash with single-dash in prose and tables

### DIFF
--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/index.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/index.mdx
@@ -13,8 +13,8 @@ Full prop tables, return types, and type definitions for every export in `@gentl
 
 | Export | Description |
 | :--- | :--- |
-| [useCalendar](/docs/packages/duck-calendar/api/use-calendar) | Main calendar hook -- state, actions, and prop getters |
-| [useTimePicker](/docs/packages/duck-calendar/api/use-time-picker) | Time picker hook -- spinbutton fields and keyboard input |
+| [useCalendar](/docs/packages/duck-calendar/api/use-calendar) | Main calendar hook  -  state, actions, and prop getters |
+| [useTimePicker](/docs/packages/duck-calendar/api/use-time-picker) | Time picker hook  -  spinbutton fields and keyboard input |
 | [useDateTime](/docs/packages/duck-calendar/api/use-datetime) | Combined date + time hook |
 | `useAnnouncer` | Screen reader announcement hook |
 | `useKeyboard` | Keyboard navigation hook |
@@ -23,9 +23,9 @@ Full prop tables, return types, and type definitions for every export in `@gentl
 
 | Export | Description |
 | :--- | :--- |
-| [Grid](/docs/packages/duck-calendar/api/grid) | Grid builder functions -- `buildCalendarMonth`, `buildMultiMonth`, etc. |
-| [Selection](/docs/packages/duck-calendar/api/selection) | Selection logic -- `selectDay`, `applySelection` |
-| [Navigation](/docs/packages/duck-calendar/api/navigation) | Navigation functions -- `navigate`, `canNavigate` |
+| [Grid](/docs/packages/duck-calendar/api/grid) | Grid builder functions  -  `buildCalendarMonth`, `buildMultiMonth`, etc. |
+| [Selection](/docs/packages/duck-calendar/api/selection) | Selection logic  -  `selectDay`, `applySelection` |
+| [Navigation](/docs/packages/duck-calendar/api/navigation) | Navigation functions  -  `navigate`, `canNavigate` |
 | `isDateDisabled` | Check if a date is disabled by the current constraints |
 | `isInRange` | Check if a date falls within a range |
 | `clampTime` | Clamp a time value to min/max bounds |

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/selection.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/selection.mdx
@@ -11,7 +11,7 @@ import { selectDay, applySelection } from '@gentleduck/calendar'
 
 ### `selectDay`
 
-Compute the new selection value when a user clicks a day. Pure function -- does not mutate state.
+Compute the new selection value when a user clicks a day. Pure function  -  does not mutate state.
 
 ```tsx
 selectDay(adapter: DateAdapter<TDate>, mode: SelectionMode, current: CalendarValue<TDate, M>, date: TDate, options?: { shiftKey?: boolean }) => CalendarValue<TDate, M>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/use-calendar.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/use-calendar.mdx
@@ -27,20 +27,20 @@ const { state, actions, getDayProps, getGridProps, getNavProps, getHeaderProps, 
 | :--- | :--- | :--- | :--- |
 | `adapter` | `DateAdapter<TDate>` | **required** | Date adapter instance |
 | `mode` | `SelectionMode` | **required** | `'single'`, `'range'`, `'multi'`, or `'multi-range'` |
-| `locale` | `CalendarLocaleConfig` | -- | Locale, week start day, and direction |
-| `month` | `TDate` | -- | Controlled displayed month |
+| `locale` | `CalendarLocaleConfig` | - | Locale, week start day, and direction |
+| `month` | `TDate` | - | Controlled displayed month |
 | `defaultMonth` | `TDate` | `adapter.today()` | Default month (uncontrolled) |
-| `selected` | `CalendarValue<TDate, M>` | -- | Controlled selection value |
-| `defaultSelected` | `CalendarValue<TDate, M>` | -- | Default selection (uncontrolled) |
-| `onSelect` | `(value) => void` | -- | Called when selection changes |
-| `onMonthChange` | `(month) => void` | -- | Called when displayed month changes |
-| `onDismiss` | `() => void` | -- | Called on <Kbd>Escape</Kbd> |
+| `selected` | `CalendarValue<TDate, M>` | - | Controlled selection value |
+| `defaultSelected` | `CalendarValue<TDate, M>` | - | Default selection (uncontrolled) |
+| `onSelect` | `(value) => void` | - | Called when selection changes |
+| `onMonthChange` | `(month) => void` | - | Called when displayed month changes |
+| `onDismiss` | `() => void` | - | Called on <Kbd>Escape</Kbd> |
 | `numberOfMonths` | `number` | `1` | Number of months to display side by side |
 | `showOutsideDays` | `boolean` | `true` | Show days from adjacent months |
 | `fixedWeeks` | `boolean` | `false` | Always show 6 weeks |
-| `disabled` | `TDate[] \| (date) => boolean` | -- | Dates that cannot be selected |
-| `fromDate` | `TDate` | -- | Earliest selectable date |
-| `toDate` | `TDate` | -- | Latest selectable date |
+| `disabled` | `TDate[] \| (date) => boolean` | - | Dates that cannot be selected |
+| `fromDate` | `TDate` | - | Earliest selectable date |
+| `toDate` | `TDate` | - | Latest selectable date |
 
 #### `CalendarLocaleConfig`
 

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/use-datetime.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/use-datetime.mdx
@@ -34,19 +34,19 @@ function MyDateTimePicker() {
 | Prop | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `adapter` | `DateAdapter<TDate>` | **required** | Date adapter instance |
-| `locale` | `CalendarLocaleConfig` | -- | Locale and direction settings |
-| `value` | `TDate` | -- | Controlled datetime value |
-| `defaultValue` | `TDate` | -- | Default datetime (uncontrolled) |
-| `onChange` | `(value: TDate) => void` | -- | Called when date or time changes |
+| `locale` | `CalendarLocaleConfig` | - | Locale and direction settings |
+| `value` | `TDate` | - | Controlled datetime value |
+| `defaultValue` | `TDate` | - | Default datetime (uncontrolled) |
+| `onChange` | `(value: TDate) => void` | - | Called when date or time changes |
 | `hourCycle` | `HourCycle` | `'24'` | `'12'` or `'24'` hour display |
 | `showSeconds` | `boolean` | `false` | Show the seconds field |
-| `month` | `TDate` | -- | Controlled displayed month |
-| `defaultMonth` | `TDate` | -- | Default month (uncontrolled) |
-| `onMonthChange` | `(month: TDate) => void` | -- | Called when month changes |
-| `disabled` | `TDate[] \| (date) => boolean` | -- | Disabled dates |
-| `fromDate` | `TDate` | -- | Earliest selectable date |
-| `toDate` | `TDate` | -- | Latest selectable date |
-| `onDismiss` | `() => void` | -- | Called on <Kbd>Escape</Kbd> |
+| `month` | `TDate` | - | Controlled displayed month |
+| `defaultMonth` | `TDate` | - | Default month (uncontrolled) |
+| `onMonthChange` | `(month: TDate) => void` | - | Called when month changes |
+| `disabled` | `TDate[] \| (date) => boolean` | - | Disabled dates |
+| `fromDate` | `TDate` | - | Earliest selectable date |
+| `toDate` | `TDate` | - | Latest selectable date |
+| `onDismiss` | `() => void` | - | Called on <Kbd>Escape</Kbd> |
 
 ---
 

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/use-time-picker.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/use-time-picker.mdx
@@ -37,13 +37,13 @@ function MyTimePicker() {
 
 | Prop | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `value` | `TimeValue` | -- | Controlled time value |
+| `value` | `TimeValue` | - | Controlled time value |
 | `defaultValue` | `TimeValue` | `{ hour: 0, minute: 0 }` | Default time (uncontrolled) |
-| `onChange` | `(value: TimeValue) => void` | -- | Called when time changes |
+| `onChange` | `(value: TimeValue) => void` | - | Called when time changes |
 | `hourCycle` | `HourCycle` | `'24'` | `'12'` or `'24'` hour display |
 | `showSeconds` | `boolean` | `false` | Show the seconds field |
-| `minTime` | `TimeValue` | -- | Minimum selectable time |
-| `maxTime` | `TimeValue` | -- | Maximum selectable time |
+| `minTime` | `TimeValue` | - | Minimum selectable time |
+| `maxTime` | `TimeValue` | - | Maximum selectable time |
 | `minuteStep` | `number` | `1` | Step increment for minutes |
 | `secondStep` | `number` | `1` | Step increment for seconds |
 

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/01-introduction.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/01-introduction.mdx
@@ -13,17 +13,17 @@ description: "Why we built our own calendar engine and what problems it solves."
 
 Every React calendar library we evaluated had at least one of these problems:
 
-- **Too large** -- `react-datepicker` ships 32 KB gzipped with 3 runtime dependencies
-- **Coupled to a date library** -- `react-day-picker` requires `date-fns` (adds ~15 KB)
-- **Not tree-shakeable** -- monolithic components that bundle everything even if you only need a date picker
-- **Ships CSS** -- forces you to import and override stylesheets
+- **Too large**  -  `react-datepicker` ships 32 KB gzipped with 3 runtime dependencies
+- **Coupled to a date library**  -  `react-day-picker` requires `date-fns` (adds ~15 KB)
+- **Not tree-shakeable**  -  monolithic components that bundle everything even if you only need a date picker
+- **Ships CSS**  -  forces you to import and override stylesheets
 
 We wanted something that was:
 
 - Under 10 KB gzipped with zero dependencies
 - Pluggable for any date library via an adapter
-- Fully headless -- no opinions on rendering
-- Accessible by default -- WAI-ARIA grid pattern baked in
+- Fully headless  -  no opinions on rendering
+- Accessible by default  -  WAI-ARIA grid pattern baked in
 
 ---
 
@@ -54,6 +54,6 @@ By the end of this course, you will have:
 
 <Callout icon={<MapIcon />}>
 
-Next: [Lesson 2 -- Adapter Pattern](/docs/packages/duck-calendar/course/02-adapter-pattern)
+Next: [Lesson 2  -  Adapter Pattern](/docs/packages/duck-calendar/course/02-adapter-pattern)
 
 </Callout>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/02-adapter-pattern.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/02-adapter-pattern.mdx
@@ -28,7 +28,7 @@ Without an adapter, the calendar engine would have to call `new Date()`, `date.g
 
 With an adapter:
 
-- The engine is **date-library agnostic** -- swap adapters without changing any rendering code
+- The engine is **date-library agnostic**  -  swap adapters without changing any rendering code
 - You can write **isomorphic helpers** that work with any `TDate`
 - The adapter is the **single source of truth** for date operations
 
@@ -108,7 +108,7 @@ const dayjsAdapter: DateAdapter<Dayjs> = {
 
 <Callout icon={<TriangleAlert />} tone="warning">
 
-All adapter methods must be **immutable**. Never mutate the input date -- always return a new instance.
+All adapter methods must be **immutable**. Never mutate the input date  -  always return a new instance.
 
 </Callout>
 
@@ -116,13 +116,13 @@ All adapter methods must be **immutable**. Never mutate the input date -- always
 
 ## Key takeaways
 
-- The adapter is a plain object -- no classes, no inheritance
+- The adapter is a plain object  -  no classes, no inheritance
 - Every date operation goes through the adapter
 - The `NativeAdapter` is good enough for most projects
 - Custom adapters are ~30 lines of code
 
 <Callout icon={<MapIcon />}>
 
-Next: [Lesson 3 -- Building a Grid](/docs/packages/duck-calendar/course/03-building-a-grid)
+Next: [Lesson 3  -  Building a Grid](/docs/packages/duck-calendar/course/03-building-a-grid)
 
 </Callout>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/03-building-a-grid.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/03-building-a-grid.mdx
@@ -150,6 +150,6 @@ buildCalendarMonth(adapter, date, {
 
 <Callout icon={<MapIcon />}>
 
-Next: [Lesson 4 -- Selection Modes](/docs/packages/duck-calendar/course/04-selection-modes)
+Next: [Lesson 4  -  Selection Modes](/docs/packages/duck-calendar/course/04-selection-modes)
 
 </Callout>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/04-selection-modes.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/04-selection-modes.mdx
@@ -130,6 +130,6 @@ useCalendar({
 
 <Callout icon={<MapIcon />}>
 
-Next: [Lesson 5 -- Keyboard and Accessibility](/docs/packages/duck-calendar/course/05-keyboard-a11y)
+Next: [Lesson 5  -  Keyboard and Accessibility](/docs/packages/duck-calendar/course/05-keyboard-a11y)
 
 </Callout>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/05-keyboard-a11y.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/05-keyboard-a11y.mdx
@@ -110,6 +110,6 @@ Key things to check:
 
 <Callout icon={<MapIcon />}>
 
-Next: [Lesson 6 -- Time Picker](/docs/packages/duck-calendar/course/06-time-picker)
+Next: [Lesson 6  -  Time Picker](/docs/packages/duck-calendar/course/06-time-picker)
 
 </Callout>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/06-time-picker.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/06-time-picker.mdx
@@ -39,7 +39,7 @@ function MyTimePicker() {
 
 ## How it works
 
-Each field is a `spinbutton` -- users can:
+Each field is a `spinbutton`  -  users can:
 
 - **Type** a number to set the value directly
 - Press <Kbd>ArrowUp</Kbd> / <Kbd>ArrowDown</Kbd> to increment/decrement
@@ -120,6 +120,6 @@ useTimePicker({
 
 <Callout icon={<MapIcon />}>
 
-Next: [Lesson 7 -- Styling](/docs/packages/duck-calendar/course/07-styling)
+Next: [Lesson 7  -  Styling](/docs/packages/duck-calendar/course/07-styling)
 
 </Callout>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/07-styling.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/07-styling.mdx
@@ -5,7 +5,7 @@ description: "Using data attributes to style the calendar with Tailwind or plain
 
 <Callout icon={<Lightbulb />}>
 
-**Lesson 7 of 8**: You will learn how to style every part of the calendar using data attributes -- no CSS imports, no specificity wars.
+**Lesson 7 of 8**: You will learn how to style every part of the calendar using data attributes  -  no CSS imports, no specificity wars.
 
 </Callout>
 
@@ -136,6 +136,6 @@ When using `@gentleduck/primitives/calendar`, each component adds a `data-slot` 
 
 <Callout icon={<MapIcon />}>
 
-Next: [Lesson 8 -- Performance](/docs/packages/duck-calendar/course/08-performance)
+Next: [Lesson 8  -  Performance](/docs/packages/duck-calendar/course/08-performance)
 
 </Callout>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/08-performance.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/08-performance.mdx
@@ -13,7 +13,7 @@ description: "Benchmarks, bundle size comparisons, and optimization strategies."
 
 We replaced `react-day-picker` with `@gentleduck/calendar`. Here is how we compare against every major React calendar library.
 
-### Bundle size -- all competitors
+### Bundle size  -  all competitors
 
 | Library | Bundle (gzipped) | Improvement |
 | :--- | :--- | :--- |
@@ -68,22 +68,22 @@ cd packages/duck-calendar && bun run benchmark
 
 These are the specific optimizations that brought the core bundle from 7.0 KB down to 4.9 KB gzipped (75% smaller than react-day-picker):
 
-- **Intl.DateTimeFormat caching** -- formatters are cached per locale+options key, avoiding expensive re-instantiation
-- **React.memo on day cells** -- prevents re-rendering 42 unchanged cells on selection change
-- **Stable keyboard callback** -- uses configRef pattern for zero re-creation cost
-- **Pre-computed time field orders** -- 4 static arrays replace Array.filter() on every keystroke
-- **Frozen selection constants** -- UNSELECTED object reused across all unselected days
-- **Dev JSX elimination** -- production build uses createElement directly, no jsxDEV metadata
+- **Intl.DateTimeFormat caching**  -  formatters are cached per locale+options key, avoiding expensive re-instantiation
+- **React.memo on day cells**  -  prevents re-rendering 42 unchanged cells on selection change
+- **Stable keyboard callback**  -  uses configRef pattern for zero re-creation cost
+- **Pre-computed time field orders**  -  4 static arrays replace Array.filter() on every keystroke
+- **Frozen selection constants**  -  UNSELECTED object reused across all unselected days
+- **Dev JSX elimination**  -  production build uses createElement directly, no jsxDEV metadata
 
 ---
 
 ## Why it is fast
 
-- **Pure functions** -- grid building and selection are pure functions that do not allocate closures or manage subscriptions
-- **No date library dependency** -- the `NativeAdapter` uses only native `Date` and `Intl.DateTimeFormat`
-- **Tree-shakeable** -- import only what you use. If you only need `buildCalendarMonth`, the rest is eliminated
-- **Minimal React overhead** -- the hooks use `useMemo` to avoid rebuilding grids on every render
-- **No CSS runtime** -- no CSS-in-JS overhead, no stylesheet injection
+- **Pure functions**  -  grid building and selection are pure functions that do not allocate closures or manage subscriptions
+- **No date library dependency**  -  the `NativeAdapter` uses only native `Date` and `Intl.DateTimeFormat`
+- **Tree-shakeable**  -  import only what you use. If you only need `buildCalendarMonth`, the rest is eliminated
+- **Minimal React overhead**  -  the hooks use `useMemo` to avoid rebuilding grids on every render
+- **No CSS runtime**  -  no CSS-in-JS overhead, no stylesheet injection
 
 ---
 

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/index.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/index.mdx
@@ -13,20 +13,20 @@ This course takes you from zero to a fully styled, accessible calendar with date
 
 <Steps>
 
-<Step>[Introduction](/docs/packages/duck-calendar/course/01-introduction) -- Why we built the engine and what problems it solves</Step>
+<Step>[Introduction](/docs/packages/duck-calendar/course/01-introduction)  -  Why we built the engine and what problems it solves</Step>
 
-<Step>[Adapter Pattern](/docs/packages/duck-calendar/course/02-adapter-pattern) -- Understanding `DateAdapter<TDate>` and plugging in any date library</Step>
+<Step>[Adapter Pattern](/docs/packages/duck-calendar/course/02-adapter-pattern)  -  Understanding `DateAdapter<TDate>` and plugging in any date library</Step>
 
-<Step>[Building a Grid](/docs/packages/duck-calendar/course/03-building-a-grid) -- Using `buildCalendarMonth` to generate and render month grids</Step>
+<Step>[Building a Grid](/docs/packages/duck-calendar/course/03-building-a-grid)  -  Using `buildCalendarMonth` to generate and render month grids</Step>
 
-<Step>[Selection Modes](/docs/packages/duck-calendar/course/04-selection-modes) -- Single, range, and multi-select with `useCalendar`</Step>
+<Step>[Selection Modes](/docs/packages/duck-calendar/course/04-selection-modes)  -  Single, range, and multi-select with `useCalendar`</Step>
 
-<Step>[Keyboard and Accessibility](/docs/packages/duck-calendar/course/05-keyboard-a11y) -- WAI-ARIA grid pattern, roving tabIndex, and screen reader support</Step>
+<Step>[Keyboard and Accessibility](/docs/packages/duck-calendar/course/05-keyboard-a11y)  -  WAI-ARIA grid pattern, roving tabIndex, and screen reader support</Step>
 
-<Step>[Time Picker](/docs/packages/duck-calendar/course/06-time-picker) -- `useTimePicker` and `useDateTime` for time input</Step>
+<Step>[Time Picker](/docs/packages/duck-calendar/course/06-time-picker)  -  `useTimePicker` and `useDateTime` for time input</Step>
 
-<Step>[Styling](/docs/packages/duck-calendar/course/07-styling) -- Data attributes, Tailwind, and plain CSS approaches</Step>
+<Step>[Styling](/docs/packages/duck-calendar/course/07-styling)  -  Data attributes, Tailwind, and plain CSS approaches</Step>
 
-<Step>[Performance](/docs/packages/duck-calendar/course/08-performance) -- Benchmarks, bundle analysis, and optimization strategies</Step>
+<Step>[Performance](/docs/packages/duck-calendar/course/08-performance)  -  Benchmarks, bundle analysis, and optimization strategies</Step>
 
 </Steps>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/getting-started.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/getting-started.mdx
@@ -144,7 +144,7 @@ function MyCalendar() {
 
 <Callout icon={<Lightbulb />}>
 
-The hook approach and compound components use the same engine underneath. Choose whichever fits your project best -- you can always switch later.
+The hook approach and compound components use the same engine underneath. Choose whichever fits your project best  -  you can always switch later.
 
 </Callout>
 
@@ -154,9 +154,9 @@ The hook approach and compound components use the same engine underneath. Choose
 
 <Callout icon={<MapIcon />} className="[&_ul]:my-0">
 
-- [Adapters](/docs/packages/duck-calendar/guides/adapters) -- Understand the date adapter pattern and plug in any date library.
-- [Selection Modes](/docs/packages/duck-calendar/api/use-calendar) -- Single, range, and multi-select.
-- [Styling](/docs/packages/duck-calendar/guides/styling) -- Style with data attributes and Tailwind.
-- [Course](/docs/packages/duck-calendar/course) -- Hands-on tutorial from zero to production.
+- [Adapters](/docs/packages/duck-calendar/guides/adapters)  -  Understand the date adapter pattern and plug in any date library.
+- [Selection Modes](/docs/packages/duck-calendar/api/use-calendar)  -  Single, range, and multi-select.
+- [Styling](/docs/packages/duck-calendar/guides/styling)  -  Style with data attributes and Tailwind.
+- [Course](/docs/packages/duck-calendar/course)  -  Hands-on tutorial from zero to production.
 
 </Callout>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/guides/accessibility.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/guides/accessibility.mdx
@@ -13,9 +13,9 @@ The calendar follows the [WAI-ARIA Grid Pattern](https://www.w3.org/WAI/ARIA/apg
 
 | Element | Role / Attribute | Value |
 | :--- | :--- | :--- |
-| Grid container | `role="grid"` | -- |
+| Grid container | `role="grid"` | - |
 | Grid container | `aria-roledescription` | `"calendar"` |
-| Day cell | `role="gridcell"` | -- |
+| Day cell | `role="gridcell"` | - |
 | Day cell | `aria-label` | Full date (e.g. "Saturday, March 14, 2026") |
 | Day cell | `aria-selected` | `true` when selected |
 | Day cell | `aria-disabled` | `true` when disabled |

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/guides/adapters.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/guides/adapters.mdx
@@ -5,7 +5,7 @@ description: "Understand the DateAdapter pattern and how to plug in any date lib
 
 ## The adapter pattern
 
-The `DateAdapter<TDate>` interface abstracts all date operations. The engine never calls `new Date()` or `date.getMonth()` directly -- everything goes through the adapter.
+The `DateAdapter<TDate>` interface abstracts all date operations. The engine never calls `new Date()` or `date.getMonth()` directly  -  everything goes through the adapter.
 
 This means you can swap `Date` for dayjs, date-fns, Luxon, or a non-Gregorian calendar without changing any calendar logic.
 
@@ -130,6 +130,6 @@ Every adapter must implement these methods:
 
 <Callout icon={<TriangleAlert />} tone="warning">
 
-All date operations must be immutable -- never mutate the input date. Return a new instance instead.
+All date operations must be immutable  -  never mutate the input date. Return a new instance instead.
 
 </Callout>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/guides/styling.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/guides/styling.mdx
@@ -123,6 +123,6 @@ When using compound components from `@gentleduck/primitives/calendar`, each comp
 
 <Callout icon={<Lightbulb />}>
 
-The headless approach means zero specificity conflicts. You own every pixel and can use any CSS methodology -- Tailwind, CSS modules, styled-components, or plain stylesheets.
+The headless approach means zero specificity conflicts. You own every pixel and can use any CSS methodology  -  Tailwind, CSS modules, styled-components, or plain stylesheets.
 
 </Callout>

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/index.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/index.mdx
@@ -5,7 +5,7 @@ description: "Headless, framework-agnostic calendar engine with date adapter pat
 
 <Callout icon={<Zap />}>
 
-`@gentleduck/calendar` is a headless calendar engine that owns the entire date-picking stack. No opinions on how your calendar looks -- only on how it works.
+`@gentleduck/calendar` is a headless calendar engine that owns the entire date-picking stack. No opinions on how your calendar looks  -  only on how it works.
 
 </Callout>
 
@@ -42,13 +42,13 @@ We built this to replace `react-day-picker`. The numbers speak for themselves:
 
 <Steps>
 
-<Step>**Core** -- Pure functions for grid building, selection logic, and navigation. No React, no state, no side effects.</Step>
+<Step>**Core**  -  Pure functions for grid building, selection logic, and navigation. No React, no state, no side effects.</Step>
 
-<Step>**Adapter** -- A `DateAdapter<TDate>` interface that abstracts date operations. Ships with a zero-dependency `NativeAdapter` for `Date`. Plug in dayjs, date-fns, or Temporal when needed.</Step>
+<Step>**Adapter**  -  A `DateAdapter<TDate>` interface that abstracts date operations. Ships with a zero-dependency `NativeAdapter` for `Date`. Plug in dayjs, date-fns, or Temporal when needed.</Step>
 
-<Step>**React hooks** -- `useCalendar`, `useTimePicker`, `useDateTime` manage state and produce prop getters you spread onto your elements.</Step>
+<Step>**React hooks**  -  `useCalendar`, `useTimePicker`, `useDateTime` manage state and produce prop getters you spread onto your elements.</Step>
 
-<Step>**Compound components** -- Available in `@gentleduck/primitives/calendar` for consumers who want convenience. Optional -- hooks are first-class.</Step>
+<Step>**Compound components**  -  Available in `@gentleduck/primitives/calendar` for consumers who want convenience. Optional  -  hooks are first-class.</Step>
 
 </Steps>
 
@@ -58,11 +58,11 @@ We built this to replace `react-day-picker`. The numbers speak for themselves:
 
 We replaced `react-day-picker` with this package. Every existing React calendar library either bundles too much CSS, mandates a specific date library, or ships a monolithic component you cannot tree-shake. `@gentleduck/calendar` solves all three:
 
-- **~5 KB gzipped** -- 3-9x smaller than every alternative
-- **Zero runtime dependencies** -- the `NativeAdapter` uses only `Date` + `Intl.DateTimeFormat`
-- **Pluggable date backend** -- swap `Date` for dayjs, date-fns, or the Temporal API without changing any calendar code
-- **Headless** -- no CSS shipped, style with data attributes and Tailwind
-- **Accessible** -- full WAI-ARIA grid pattern, keyboard navigation, screen reader announcements
+- **~5 KB gzipped**  -  3-9x smaller than every alternative
+- **Zero runtime dependencies**  -  the `NativeAdapter` uses only `Date` + `Intl.DateTimeFormat`
+- **Pluggable date backend**  -  swap `Date` for dayjs, date-fns, or the Temporal API without changing any calendar code
+- **Headless**  -  no CSS shipped, style with data attributes and Tailwind
+- **Accessible**  -  full WAI-ARIA grid pattern, keyboard navigation, screen reader announcements
 
 ---
 
@@ -88,9 +88,9 @@ We replaced `react-day-picker` with this package. Every existing React calendar 
 
 <Callout icon={<MapIcon />} className="[&_ul]:my-0">
 
-- [Getting Started](/docs/packages/duck-calendar/getting-started) -- Install and build your first calendar in under 5 minutes.
-- [Guides](/docs/packages/duck-calendar/guides) -- Adapters, styling, and accessibility.
-- [API Reference](/docs/packages/duck-calendar/api) -- Full prop and return type reference.
-- [Course](/docs/packages/duck-calendar/course) -- Hands-on lessons from zero to production.
+- [Getting Started](/docs/packages/duck-calendar/getting-started)  -  Install and build your first calendar in under 5 minutes.
+- [Guides](/docs/packages/duck-calendar/guides)  -  Adapters, styling, and accessibility.
+- [API Reference](/docs/packages/duck-calendar/api)  -  Full prop and return type reference.
+- [Course](/docs/packages/duck-calendar/course)  -  Hands-on lessons from zero to production.
 
 </Callout>


### PR DESCRIPTION
## Summary
- Normalized `--` (double dash) to `-` (single dash) across all 19 duck-calendar MDX files
- Table default cells: `| -- |` changed to `| - |`
- Prose separators: ` -- ` changed to `  -  ` (spaced single dash)
- Preserved `---` (frontmatter/horizontal rules), `-->` (Mermaid arrows), `var(--...)` (CSS custom properties), and `--` inside code blocks

## Test plan
- [x] Verified no `--` remains outside code blocks, frontmatter, Mermaid diagrams, and CSS custom properties
- [x] MDX-only change, no runtime impact