### PR TITLE
docs: replace double-dash with single-dash in changelog and comparisons

### DIFF
--- a/apps/duck-ui-docs/content/docs/changelog/2024.mdx
+++ b/apps/duck-ui-docs/content/docs/changelog/2024.mdx
@@ -1,6 +1,6 @@
 ---
 title: "2024"
-description: Project foundation -- monorepo migration, table system, upload/audio/comments, registry, emoji system, kanban, and initial components.
+description: Project foundation  -  monorepo migration, table system, upload/audio/comments, registry, emoji system, kanban, and initial components.
 ---
 
 ## November 2024

--- a/apps/duck-ui-docs/content/docs/changelog/index.mdx
+++ b/apps/duck-ui-docs/content/docs/changelog/index.mdx
@@ -1,14 +1,14 @@
 ---
 title: Changelog
-description: A complete history of updates, features, fixes, and improvements to gentleduck/ui -- organized by month.
+description: A complete history of updates, features, fixes, and improvements to gentleduck/ui  -  organized by month.
 ---
 
-## Latest -- March 2026
+## Latest  -  March 2026
 
 @gentleduck/calendar headless engine with 4 calendar systems, full calendar block, Presence animation interrupt fix, registry-build extensions, CLI v1.2.0, vim engine, and 16 package releases.
 
 <LinkedCard href="/docs/changelog/march-2026">
-  March 2026 -- Calendar Engine, Calendar Block, Presence Fix, Registry Build, CLI v1.2.0
+  March 2026  -  Calendar Engine, Calendar Block, Presence Fix, Registry Build, CLI v1.2.0
 </LinkedCard>
 
 ---

--- a/apps/duck-ui-docs/content/docs/changelog/march-2026.mdx
+++ b/apps/duck-ui-docs/content/docs/changelog/march-2026.mdx
@@ -3,9 +3,9 @@ title: March 2026
 description: "@gentleduck/calendar headless engine, full calendar block, Presence animation fix, registry-build extensions, CLI v1.2.0, vim engine, and version releases."
 ---
 
-## @gentleduck/calendar -- Headless Calendar Engine <Badge>feat</Badge>
+## @gentleduck/calendar  -  Headless Calendar Engine <Badge>feat</Badge>
 
-Published [`@gentleduck/calendar`](https://www.npmjs.com/package/@gentleduck/calendar) -- a headless, zero-dependency calendar engine for React.
+Published [`@gentleduck/calendar`](https://www.npmjs.com/package/@gentleduck/calendar)  -  a headless, zero-dependency calendar engine for React.
 
 ### What it does
 
@@ -109,7 +109,7 @@ Shipped a fully styled `Calendar` in `@gentleduck/registry-ui` with month/year d
 | `applySelection` | ~13 us |
 | Tests | 857 across 21 files |
 
-### v0.2.0 -- Code Review Hardening
+### v0.2.0  -  Code Review Hardening
 
 Ran 60+ automated review agents across every file. Key fixes:
 
@@ -161,15 +161,15 @@ This fix applies to all animated primitives: Popover, Dialog, AlertDialog, Sheet
 
 ## Hydration and Accessibility Fixes <Badge>fix</Badge>
 
-- **Breadcrumb key warning** -- moved React `key` from `BreadcrumbItem` to `Fragment` wrapper in `DocsPathBreadcrumb`
-- **Theme toggle hydration mismatch** -- server rendered "Switch to dark theme" while client resolved to "Switch to light theme". Fixed with a `mounted` guard that shows "Toggle theme" until client hydration completes
-- **Nested button violation** -- `PopoverTrigger` wrapping `Button` without `asChild` produced `<button>` inside `<button>`. Fixed in `calendar-7` and `combobox-7` examples
-- **Primitives useMemo stability** -- `Calendar` root's `useMemo` depended on `useCalendar` return object (new ref every render). Destructured into stable individual values
-- **Registry-ui NumberFormat cache** -- added LRU eviction (max 20) to prevent unbounded memory growth
+- **Breadcrumb key warning**  -  moved React `key` from `BreadcrumbItem` to `Fragment` wrapper in `DocsPathBreadcrumb`
+- **Theme toggle hydration mismatch**  -  server rendered "Switch to dark theme" while client resolved to "Switch to light theme". Fixed with a `mounted` guard that shows "Toggle theme" until client hydration completes
+- **Nested button violation**  -  `PopoverTrigger` wrapping `Button` without `asChild` produced `<button>` inside `<button>`. Fixed in `calendar-7` and `combobox-7` examples
+- **Primitives useMemo stability**  -  `Calendar` root's `useMemo` depended on `useCalendar` return object (new ref every render). Destructured into stable individual values
+- **Registry-ui NumberFormat cache**  -  added LRU eviction (max 20) to prevent unbounded memory growth
 
 ---
 
-## Registry Build -- Extension-Driven Architecture <Badge>feat</Badge>
+## Registry Build  -  Extension-Driven Architecture <Badge>feat</Badge>
 
 Major refactoring of `@gentleduck/registry-build` into a fully extension-driven build system with generic collections support.
 
@@ -177,12 +177,12 @@ Major refactoring of `@gentleduck/registry-build` into a fully extension-driven 
 
 The core runner no longer has built-in index or components phases. All processing is now performed by explicit extensions that consumers register in their config:
 
-- `bannerExtension()` -- CLI banner output (beforeBuild)
-- `validateExtension()` -- source path and registry entry validation (beforeBuild)
-- `indexBuildExtension()` -- registry entry materialization and `index.json` generation (afterBuild)
-- `componentsExtension()` -- per-item JSON component payload generation (afterBuild)
-- `componentIndexExtension()` -- framework-specific import index generation (afterBuild)
-- `colorsExtension()` -- theme CSS and color JSON generation (afterBuild)
+- `bannerExtension()`  -  CLI banner output (beforeBuild)
+- `validateExtension()`  -  source path and registry entry validation (beforeBuild)
+- `indexBuildExtension()`  -  registry entry materialization and `index.json` generation (afterBuild)
+- `componentsExtension()`  -  per-item JSON component payload generation (afterBuild)
+- `componentIndexExtension()`  -  framework-specific import index generation (afterBuild)
+- `colorsExtension()`  -  theme CSS and color JSON generation (afterBuild)
 
 Use `uiRegistryPreset()` to bundle all standard UI extensions, or register them individually for full control.
 
@@ -208,7 +208,7 @@ See the full [registry-build docs](/docs/packages/duck-registry-build).
 
 ---
 
-## CLI v1.2.0 -- Merge and Diff GUI <Badge>feat</Badge>
+## CLI v1.2.0  -  Merge and Diff GUI <Badge>feat</Badge>
 
 Major overhaul of `@gentleduck/cli` with an interactive terminal UI for resolving merge conflicts and reviewing diffs.
 

--- a/apps/duck-ui-docs/content/docs/comparisons/index.mdx
+++ b/apps/duck-ui-docs/content/docs/comparisons/index.mdx
@@ -9,12 +9,12 @@ Honest, side-by-side comparisons with the libraries you're evaluating. Each page
 
 ### Calendar
 
-- [**vs react-day-picker**](/docs/comparisons/vs-react-day-picker) -- `@gentleduck/calendar` compared to react-day-picker. Bundle size (~5 KB vs ~20 KB gzipped), adapter pattern, selection modes, ARIA grid compliance.
+- [**vs react-day-picker**](/docs/comparisons/vs-react-day-picker)  -  `@gentleduck/calendar` compared to react-day-picker. Bundle size (~5 KB vs ~20 KB gzipped), adapter pattern, selection modes, ARIA grid compliance.
 
 ### Primitives
 
-- [**vs Radix UI**](/docs/comparisons/vs-radix) -- `@gentleduck/primitives` compared to Radix UI Primitives. Same compound-component API, full source ownership, Calendar primitive included. [Bundle size benchmarks](/docs/packages/duck-primitives/benchmarks).
+- [**vs Radix UI**](/docs/comparisons/vs-radix)  -  `@gentleduck/primitives` compared to Radix UI Primitives. Same compound-component API, full source ownership, Calendar primitive included. [Bundle size benchmarks](/docs/packages/duck-primitives/benchmarks).
 
 ### Full Framework
 
-- [**vs shadcn/ui**](/docs/comparisons/vs-shadcn) -- gentleduck/ui compared to shadcn/ui. Same copy-paste philosophy, different ecosystem: own primitives, calendar engine, keyboard engine, animation tokens, state management.
+- [**vs shadcn/ui**](/docs/comparisons/vs-shadcn)  -  gentleduck/ui compared to shadcn/ui. Same copy-paste philosophy, different ecosystem: own primitives, calendar engine, keyboard engine, animation tokens, state management.

--- a/apps/duck-ui-docs/content/docs/comparisons/vs-radix.mdx
+++ b/apps/duck-ui-docs/content/docs/comparisons/vs-radix.mdx
@@ -88,7 +88,7 @@ Both implement WAI-ARIA authoring practices. Dialog manages focus trapping, esca
 
 Radix primitives live in `node_modules`. You consume them as a dependency, versioned by the Radix team. Customizing behavior means forking or wrapping.
 
-gentleduck primitives live in your monorepo as `packages/duck-primitives/`. You can modify any internal -- focus trapping logic, dismiss behavior, animation integration -- directly. The build step (tsdown) produces the same ESM output.
+gentleduck primitives live in your monorepo as `packages/duck-primitives/`. You can modify any internal  -  focus trapping logic, dismiss behavior, animation integration  -  directly. The build step (tsdown) produces the same ESM output.
 
 ### Calendar primitive
 
@@ -96,7 +96,7 @@ gentleduck primitives live in your monorepo as `packages/duck-primitives/`. You 
 
 ### Animation integration
 
-Radix provides a Presence primitive for mount/unmount animations. gentleduck extends this with `@gentleduck/motion` animation tokens -- prebuilt keyframe sets and reduced-motion utilities that integrate with the Presence lifecycle.
+Radix provides a Presence primitive for mount/unmount animations. gentleduck extends this with `@gentleduck/motion` animation tokens  -  prebuilt keyframe sets and reduced-motion utilities that integrate with the Presence lifecycle.
 
 ### Bundled together
 
@@ -111,7 +111,7 @@ Real numbers from bundlephobia.com (Radix) and built dist measurement (gentleduc
 
 <Callout icon={<Lightbulb />}>
 
-**Note:** Radio Group is one case where Radix is actually smaller (1.0 KB vs 1.9 KB). We include honest numbers -- not every primitive is smaller.
+**Note:** Radio Group is one case where Radix is actually smaller (1.0 KB vs 1.9 KB). We include honest numbers  -  not every primitive is smaller.
 
 </Callout>
 

--- a/apps/duck-ui-docs/content/docs/comparisons/vs-shadcn.mdx
+++ b/apps/duck-ui-docs/content/docs/comparisons/vs-shadcn.mdx
@@ -56,7 +56,7 @@ Both structure complex components (Dialog, Dropdown, Sheet) using the Root / Tri
 
 shadcn/ui depends on Radix UI for its headless primitives. When Radix changes behavior or deprecates an API, your styled components are affected.
 
-gentleduck/ui uses `@gentleduck/primitives` -- the same compound-component API as Radix, but you own the source. The primitives live in `packages/duck-primitives/` in your monorepo. Modify focus trapping, dismiss behavior, or animation hooks directly. See the [full comparison with Radix](/docs/comparisons/vs-radix).
+gentleduck/ui uses `@gentleduck/primitives`  -  the same compound-component API as Radix, but you own the source. The primitives live in `packages/duck-primitives/` in your monorepo. Modify focus trapping, dismiss behavior, or animation hooks directly. See the [full comparison with Radix](/docs/comparisons/vs-radix).
 
 ### Calendar engine
 
@@ -187,7 +187,7 @@ npm install -D @gentleduck/cli
 npx gentleduck init
 ```
 
-This sets up `components.json`, Tailwind config, and CSS variables -- same structure as shadcn.
+This sets up `components.json`, Tailwind config, and CSS variables  -  same structure as shadcn.
 
 ### 3. Replace components incrementally
 


### PR DESCRIPTION
## Summary

- Replaced all ` -- ` (double-dash) separators with `  -  ` (single-dash with two spaces) across 6 MDX files in changelog and comparisons docs
- Preserved `---` (frontmatter/horizontal rules), `-->` (Mermaid arrows), `--flag` (CLI arguments), and code block content

## Test plan

- [x] Verified no ` -- ` remains in target files
- [x] Verified `---`, `-->`, and `--flag` patterns are untouched
- [x] MDX-only text change, no functional impact