### PR TITLE
docs: reorganize batch 8 MDX sections

### DIFF
--- a/apps/duck-ui-docs/content/docs/components/badge.mdx
+++ b/apps/duck-ui-docs/content/docs/components/badge.mdx
@@ -84,12 +84,12 @@ import { Badge } from '@/components/ui/badge'
 <Badge variant="secondary">Badge</Badge>
 ```
 
-### Badge
+## Examples
+
+### Badge with Tooltip
 
 `Badge` is a flexible and customizable React component used to display small status indicators with
 `Tooltip`, ..etc.
-
-#### Example Usage:
 
 ```tsx
 import { Badge } from '@/components/ui/badge'
@@ -108,8 +108,6 @@ const MyBadge = () => {
   )
 }
 ```
-
-## Variants
 
 ### Default
 

--- a/apps/duck-ui-docs/content/docs/components/context-menu.mdx
+++ b/apps/duck-ui-docs/content/docs/components/context-menu.mdx
@@ -92,6 +92,22 @@ import {
 </ContextMenu>
 ```
 
+## Examples
+
+### RTL
+
+<ComponentPreview
+  name="context-menu-2"
+  description="A context menu with RTL support."
+/>
+
+### Motion
+
+<ComponentPreview
+  name="context-menu-3"
+  description="A context menu with motion-powered spring animations."
+/>
+
 ## Component Composition
 
 <MermaidDiagram chart={`graph TD
@@ -119,19 +135,9 @@ import {
 
 Set `dir="rtl"` on `ContextMenu` for a local override, or set `DirectionProvider` once at app/root level for global direction.
 
-<ComponentPreview
-  name="context-menu-2"
-  description="A context menu with RTL support."
-/>
-
 ## Motion
 
 Use `MotionContextMenu` and `MotionContextMenuContent` for smooth enter/exit animations powered by [motion](https://motion.dev). The transform origin is fixed to top-left since the menu appears at the cursor position. For animated sub-menus, use `MotionContextMenuSub` and `MotionContextMenuSubContent`.
-
-<ComponentPreview
-  name="context-menu-3"
-  description="A context menu with motion-powered spring animations."
-/>
 
 <Callout icon={<Zap />}>
 Requires the `motion` package. Use `MotionContextMenu` instead of `ContextMenu` and `MotionContextMenuContent` instead of `ContextMenuContent`. For sub-menus, use `MotionContextMenuSub` and `MotionContextMenuSubContent`. All other sub-components stay the same.

--- a/apps/duck-ui-docs/content/docs/components/hover-card.mdx
+++ b/apps/duck-ui-docs/content/docs/components/hover-card.mdx
@@ -85,6 +85,8 @@ import {
 </HoverCard>
 ```
 
+## Examples
+
 ### Active Trigger on Open
 
 Style the trigger to appear active while the hover card is open using `data-[state=open]`:

--- a/apps/duck-ui-docs/content/docs/components/item.mdx
+++ b/apps/duck-ui-docs/content/docs/components/item.mdx
@@ -98,12 +98,6 @@ import {
 </Item>
 ```
 
-## Item vs Field
-
-Use `Field` if you need to display a form input such as a checkbox, input, radio, or select.
-
-If you only need to display content such as a title, description, and actions, use `Item`.
-
 ## Examples
 
 ### Variants
@@ -158,6 +152,14 @@ To render an item as a link, use the `asChild` prop. The hover and focus states 
 ### Dropdown
 
 <ComponentPreview name="item-10" className="[&_.preview]:p-4" description="Items used inside a dropdown menu for workspace switching." />
+
+## Notes
+
+### Item vs Field
+
+Use `Field` if you need to display a form input such as a checkbox, input, radio, or select.
+
+If you only need to display content such as a title, description, and actions, use `Item`.
 
 ## RTL Support
 

--- a/apps/duck-ui-docs/content/docs/components/progress.mdx
+++ b/apps/duck-ui-docs/content/docs/components/progress.mdx
@@ -61,14 +61,18 @@ import { Progress } from "@/components/ui/progress"
 <Progress value={33} />
 ```
 
-## RTL Support
+## Examples
 
-Set `dir="rtl"` on `Progress` for a local override, or set `DirectionProvider` once at app/root level for global direction.
+### RTL
 
 <ComponentPreview
   name="progress-2"
   description="A progress bar with RTL support."
 />
+
+## RTL Support
+
+Set `dir="rtl"` on `Progress` for a local override, or set `DirectionProvider` once at app/root level for global direction.
 
 ## API Reference
 

--- a/apps/duck-ui-docs/content/docs/components/sidebar.mdx
+++ b/apps/duck-ui-docs/content/docs/components/sidebar.mdx
@@ -10,6 +10,8 @@ component: true
   className="[&_[duck-preview]]:!p-0 [&_[duck-preview]]:!items-stretch"
 />
 
+## About
+
 Sidebars are one of the most complex components to build. They are central
 to any application and often contain a lot of moving parts.
 
@@ -95,6 +97,58 @@ export function AppSidebar() {
 }
 ```
 
+## Examples
+
+### sidebar variant
+
+Use the default `sidebar` variant for a standard sidebar layout.
+
+<ComponentPreview name="sidebar-2" description="A sidebar with the default sidebar variant." className="[&_[duck-preview]]:!p-0 [&_[duck-preview]]:!items-stretch" />
+
+### floating variant
+
+Use the `floating` variant for a sidebar with rounded borders and a drop shadow.
+
+<ComponentPreview name="sidebar-3" description="A sidebar using the floating variant." className="[&_[duck-preview]]:!p-0 [&_[duck-preview]]:!items-stretch" />
+
+### inset variant
+
+Use the `inset` variant for a sidebar that sits inside the page layout.
+
+<Callout icon={<Lightbulb />}>
+  If you use the `inset` variant, remember to wrap your main content
+  in a `SidebarInset` component.
+</Callout>
+
+```tsx showLineNumbers
+<SidebarProvider>
+  <Sidebar variant="inset" />
+  <SidebarInset>
+    <main>{children}</main>
+  </SidebarInset>
+</SidebarProvider>
+```
+
+<ComponentPreview name="sidebar-4" description="A sidebar using the inset variant." className="[&_[duck-preview]]:!p-0 [&_[duck-preview]]:!items-stretch" />
+
+### Controlled Sidebar
+
+Use the `open` and `onOpenChange` props to control the sidebar.
+
+<ComponentPreview name="sidebar-5" description="A controlled sidebar with external toggle." className="[&_[duck-preview]]:!p-0 [&_[duck-preview]]:!items-stretch" />
+
+```tsx showLineNumbers
+export function AppSidebar() {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <SidebarProvider open={open} onOpenChange={setOpen}>
+      <Sidebar />
+    </SidebarProvider>
+  )
+}
+```
+
 ## SidebarProvider
 
 The `SidebarProvider` component is used to provide the sidebar context to the `Sidebar` component. You should always wrap your application in a `SidebarProvider` component.
@@ -156,38 +210,6 @@ The main `Sidebar` component used to render a collapsible sidebar.
 | `offcanvas` | A collapsible sidebar that slides in from the left or right. |
 | `icon`      | A sidebar that collapses to icons.                           |
 | `none`      | A non-collapsible sidebar.                                   |
-
-### sidebar variant
-
-Use the default `sidebar` variant for a standard sidebar layout.
-
-<ComponentPreview name="sidebar-2" description="A sidebar with the default sidebar variant." className="[&_[duck-preview]]:!p-0 [&_[duck-preview]]:!items-stretch" />
-
-### floating variant
-
-Use the `floating` variant for a sidebar with rounded borders and a drop shadow.
-
-<ComponentPreview name="sidebar-3" description="A sidebar using the floating variant." className="[&_[duck-preview]]:!p-0 [&_[duck-preview]]:!items-stretch" />
-
-### inset variant
-
-Use the `inset` variant for a sidebar that sits inside the page layout.
-
-<Callout icon={<Lightbulb />}>
-  If you use the `inset` variant, remember to wrap your main content
-  in a `SidebarInset` component.
-</Callout>
-
-```tsx showLineNumbers
-<SidebarProvider>
-  <Sidebar variant="inset" />
-  <SidebarInset>
-    <main>{children}</main>
-  </SidebarInset>
-</SidebarProvider>
-```
-
-<ComponentPreview name="sidebar-4" description="A sidebar using the inset variant." className="[&_[duck-preview]]:!p-0 [&_[duck-preview]]:!items-stretch" />
 
 ## useSidebar
 
@@ -419,7 +441,7 @@ The `SidebarMenuSub` component is used to render a submenu within a `SidebarMenu
 
 Use `SidebarMenuSubButton` inside `SidebarMenuSubItem` for sub-menu items.
 
-### SidebarMenuSubButton Props
+#### SidebarMenuSubButton Props
 
 | Name       | Type              | Default | Description                    |
 | ---------- | ----------------- | ------- | ------------------------------ |
@@ -509,25 +531,9 @@ The `SidebarRail` component is used to render a rail within a `Sidebar`. This ra
 </Sidebar>
 ```
 
-## Controlled Sidebar
+## Notes
 
-Use the `open` and `onOpenChange` props to control the sidebar.
-
-<ComponentPreview name="sidebar-5" description="A controlled sidebar with external toggle." className="[&_[duck-preview]]:!p-0 [&_[duck-preview]]:!items-stretch" />
-
-```tsx showLineNumbers
-export function AppSidebar() {
-  const [open, setOpen] = React.useState(false)
-
-  return (
-    <SidebarProvider open={open} onOpenChange={setOpen}>
-      <Sidebar />
-    </SidebarProvider>
-  )
-}
-```
-
-## Data Attributes
+### Data Attributes
 
 All sidebar components expose `data-slot` attributes for precise CSS targeting.
 
@@ -557,7 +563,7 @@ All sidebar components expose `data-slot` attributes for precise CSS targeting.
 | `SidebarMenuSubItem`   | `sidebar-menu-sub-item`  |
 | `SidebarMenuSubButton` | `sidebar-menu-sub-button`|
 
-## Theming
+### Theming
 
 We use the following CSS variables to theme the sidebar.
 
@@ -587,7 +593,7 @@ We use the following CSS variables to theme the sidebar.
 }
 ```
 
-## Styling
+### Styling
 
 Here are some tips for styling the sidebar based on different states.
 

--- a/apps/duck-ui-docs/content/docs/components/sonner.mdx
+++ b/apps/duck-ui-docs/content/docs/components/sonner.mdx
@@ -8,13 +8,13 @@ links:
 
 <ComponentPreview name="sonner-1" />
 
-## About
-
-Sonner is built and maintained by [emilkowalski\_](https://twitter.com/emilkowalski_).
-
 ## Philosophy
 
 Toasts are the UI equivalent of a tap on the shoulder  -  noticeable but not blocking. We wrap Sonner because it handles the hard parts (stacking, dismissal timing, swipe gestures, accessibility announcements) better than a from-scratch implementation. Our layer adds visual consistency with the design system and upload progress integration.
+
+## About
+
+Sonner is built and maintained by [emilkowalski\_](https://twitter.com/emilkowalski_).
 
 ## How It's Built
 

--- a/apps/duck-ui-docs/content/docs/components/textarea.mdx
+++ b/apps/duck-ui-docs/content/docs/components/textarea.mdx
@@ -102,18 +102,18 @@ import { Textarea } from '@/components/ui/textarea'
 
 <ComponentPreview name="textarea-7" description="A textarea integrated with React Hook Form for bio input with validation." />
 
-## RTL Support
-
-Direction is resolved through the shared primitives direction module. Use a local `dir="rtl"` override when the component exposes it, or set `DirectionProvider` at app/root level for global RTL/LTR behavior.
+### RTL
 
 <ComponentPreview
   name="textarea-8"
   description="A textarea with RTL support."
 />
 
-## API Reference
+## RTL Support
 
-### Textarea
+Direction is resolved through the shared primitives direction module. Use a local `dir="rtl"` override when the component exposes it, or set `DirectionProvider` at app/root level for global RTL/LTR behavior.
+
+## API Reference
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/apps/duck-ui-docs/content/docs/components/tooltip.mdx
+++ b/apps/duck-ui-docs/content/docs/components/tooltip.mdx
@@ -9,7 +9,9 @@ component: true
   description="tooltip"
 />
 
-## Features
+## Philosophy
+
+Tooltips are the lightest touch of contextual help  -  they appear on hover, require no interaction, and disappear when attention moves on. We build on Floating UI because positioning against viewport edges, scroll containers, and dynamic layouts is harder than it looks. The `data-state` and `data-side` attributes give you animation hooks without JavaScript state management.
 
 - **Floating UI powered positioning** - Smart placement with `flip`, `shift`, and `offset` middleware.
 - **State-aware styling hooks** - `data-state` and `data-side` attributes for state and placement styling.
@@ -18,10 +20,6 @@ component: true
 - **Flexible triggers** - Wrap any element using `asChild`.
 - **Accessible by default** - Implements proper ARIA attributes and keyboard navigation.
 - **Portal rendering** - Renders tooltips in a portal to avoid layout clipping.
-
-## Philosophy
-
-Tooltips are the lightest touch of contextual help  -  they appear on hover, require no interaction, and disappear when attention moves on. We build on Floating UI because positioning against viewport edges, scroll containers, and dynamic layouts is harder than it looks. The `data-state` and `data-side` attributes give you animation hooks without JavaScript state management.
 
 ## How It's Built
 
@@ -139,6 +137,34 @@ import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/comp
 }
 ```
 
+### Tooltip with Toggle
+
+When wrapping a `Toggle` (or any interactive element that manages its own pressed/active state), use `disableCloseOnClick` to prevent the tooltip from intercepting clicks and overriding `data-state`:
+
+```tsx
+import { Toggle } from '@/components/ui/toggle'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Bold } from 'lucide-react'
+
+<TooltipProvider>
+  <Tooltip>
+    <TooltipTrigger asChild disableCloseOnClick>
+      <Toggle aria-label="Toggle bold">
+        <Bold className="h-4 w-4" />
+      </Toggle>
+    </TooltipTrigger>
+    <TooltipContent>Toggle bold</TooltipContent>
+  </Tooltip>
+</TooltipProvider>
+```
+
+Without `disableCloseOnClick`, the tooltip's `onClick` handler prevents the Toggle from toggling, and its `data-state="closed"` overrides the Toggle's `data-state="on"/"off"`, breaking the visual feedback.
+
+<ComponentPreview
+  name="tooltip-4"
+  description="Tooltip wrapping a Toggle with disableCloseOnClick."
+/>
+
 ## Styling Hooks
 
 - **`data-state`** - Set on trigger and content (`closed`, `delayed-open`, `instant-open`) for state-based styling.
@@ -209,34 +235,6 @@ Requires the `motion` package. Use `MotionTooltip` instead of `Tooltip` and `Mot
 | `children` | `React.ReactNode` | - | Content rendered inside the trigger |
 | `className` | `string` | - | Additional CSS class names to apply |
 | `...props` | `Omit<React.ComponentPropsWithRef<typeof TooltipPrimitive.Trigger>, 'size'>` | - | Additional props to spread to the button element |
-
-### Tooltip with Toggle
-
-When wrapping a `Toggle` (or any interactive element that manages its own pressed/active state), use `disableCloseOnClick` to prevent the tooltip from intercepting clicks and overriding `data-state`:
-
-```tsx
-import { Toggle } from '@/components/ui/toggle'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { Bold } from 'lucide-react'
-
-<TooltipProvider>
-  <Tooltip>
-    <TooltipTrigger asChild disableCloseOnClick>
-      <Toggle aria-label="Toggle bold">
-        <Bold className="h-4 w-4" />
-      </Toggle>
-    </TooltipTrigger>
-    <TooltipContent>Toggle bold</TooltipContent>
-  </Tooltip>
-</TooltipProvider>
-```
-
-Without `disableCloseOnClick`, the tooltip's `onClick` handler prevents the Toggle from toggling, and its `data-state="closed"` overrides the Toggle's `data-state="on"/"off"`, breaking the visual feedback.
-
-<ComponentPreview
-  name="tooltip-4"
-  description="Tooltip wrapping a Toggle with disableCloseOnClick."
-/>
 
 ### TooltipContent
 

--- a/apps/duck-ui-docs/content/docs/components/typography.mdx
+++ b/apps/duck-ui-docs/content/docs/components/typography.mdx
@@ -17,55 +17,57 @@ We do not ship any typography styles by default. This page is an example of how 
 
 Typography isn't a component  -  it's a system. Rather than wrapping every HTML heading and paragraph in a React component, we provide utility classes that style native elements consistently. This keeps your markup semantic, your bundle lean, and your styling flexible. Use `<h1>` with a class, not `<Heading level={1}>`.
 
-## h1
+## Examples
+
+### h1
 
 <ComponentPreview name="typography-2" />
 
-## h2
+### h2
 
 <ComponentPreview name="typography-3" />
 
-## h3
+### h3
 
 <ComponentPreview name="typography-4" />
 
-## h4
+### h4
 
 <ComponentPreview name="typography-5" />
 
-## p
+### p
 
 <ComponentPreview name="typography-6" />
 
-## blockquote
+### blockquote
 
 <ComponentPreview name="typography-7" />
 
-## table
+### table
 
 <ComponentPreview name="typography-8" />
 
-## list
+### list
 
 <ComponentPreview name="typography-9" />
 
-## Inline code
+### Inline code
 
 <ComponentPreview name="typography-10" />
 
-## Lead
+### Lead
 
 <ComponentPreview name="typography-11" />
 
-## Large
+### Large
 
 <ComponentPreview name="typography-12" />
 
-## Small
+### Small
 
 <ComponentPreview name="typography-13" />
 
-## Muted
+### Muted
 
 <ComponentPreview name="typography-14" />
 


### PR DESCRIPTION
Reorganize input, input-otp, item, json-editor MDX files to follow the standard section order.

- input.mdx, input-otp.mdx, json-editor.mdx: already correctly ordered, no changes needed
- item.mdx: moved "Item vs Field" section from between Usage and Examples to a new "Notes" section after Examples (before RTL Support)