### PR TITLE
docs: reorganize batch 3 MDX sections

### DIFF
--- a/apps/duck-ui-docs/content/docs/components/button.mdx
+++ b/apps/duck-ui-docs/content/docs/components/button.mdx
@@ -9,7 +9,9 @@ component: true
   description="A button"
 />
 
-## Features
+## Philosophy
+
+Buttons are the primary call to action in any interface. We ship an intentionally rich variant system because buttons carry the most visual weight in UI decisions  -  primary, destructive, ghost, and outline each communicate different levels of commitment. The `asChild` pattern lets you render any element as a button, because sometimes a link needs to look like one.
 
 - Multiple **styles**, **sizes**, and **border** options out of the box
 - Built-in **loading state** with spinner and auto-disable
@@ -19,10 +21,6 @@ component: true
 - Fully **typed**, **accessible**, and **responsive**
 - Powered by `@gentleduck/variants` for scalable theming
 - Clean, composable, and **Tailwind-optimized**
-
-## Philosophy
-
-Buttons are the primary call to action in any interface. We ship an intentionally rich variant system because buttons carry the most visual weight in UI decisions  -  primary, destructive, ghost, and outline each communicate different levels of commitment. The `asChild` pattern lets you render any element as a button, because sometimes a link needs to look like one.
 
 ## How It's Built
 
@@ -265,7 +263,7 @@ When `loading` is `true`, `Button` renders a `lucide-react` `<Loader />` with `a
   description="expand icon button"
 />
 
-### RTL
+## RTL Support
 
 <ComponentPreview
   name="button-21"
@@ -287,7 +285,7 @@ Requires the `motion` package. Use `MotionButton` instead of `Button`. Same prop
 
 ## API Reference
 
-### Button Props
+### Button
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -303,7 +301,7 @@ Requires the `motion` package. Use `MotionButton` instead of `Button`. Same prop
 | `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | Native HTML button type |
 | `...props` | `Omit<React.HTMLProps<HTMLButtonElement>, 'size'>` | - | Additional props to spread to the button element |
 
-### AnimationIcon Props
+### AnimationIcon
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/apps/duck-ui-docs/content/docs/components/calendar.mdx
+++ b/apps/duck-ui-docs/content/docs/components/calendar.mdx
@@ -12,18 +12,6 @@ links:
   description="A calendar showing the current date with month/year dropdowns."
 />
 
-## Blocks
-
-We have built a collection of 30+ calendar blocks that you can use to build your own calendar components.
-
-See all calendar blocks in the [Blocks Library](/blocks/calendar) page.
-
-## Migrated from react-day-picker
-
-<Callout icon={<TriangleAlert />} tone="warning" title="Migrated from react-day-picker">
-We have replaced `react-day-picker` with our own headless calendar engine  -  [`@gentleduck/calendar`](/docs/packages/duck-calendar). The result is **75% smaller bundle** (~5 KB vs ~20 KB gzipped), zero external dependencies, full keyboard navigation, and complete ARIA compliance. See the [performance benchmarks](/docs/packages/duck-calendar#performance) for detailed comparisons.
-</Callout>
-
 ## Philosophy
 
 Calendars are complex accessibility challenges disguised as simple grids. We own the entire calendar stack  -  from the headless engine ([`@gentleduck/calendar`](/docs/packages/duck-calendar)) to the compound primitives (`@gentleduck/primitives/calendar`) to this styled component. The adapter pattern lets you swap date libraries, the hook layer handles state management, and this component applies Tailwind styling via `data-*` attribute selectors.
@@ -110,10 +98,6 @@ return (
 ```
 
 See the [@gentleduck/calendar package docs](/docs/packages/duck-calendar) for more information on the headless engine, date adapters, and advanced features.
-
-## Date Picker
-
-You can use the `<Calendar>` component to build a date picker. See the [Date Picker](/docs/components/date-picker) page for more information.
 
 ## Examples
 
@@ -292,6 +276,24 @@ You can use the `<Calendar>` component to build a date picker. See the [Date Pic
   title="Persian Calendar (English)"
   description="Jalali calendar system with English month names and LTR layout."
 />
+
+## Notes
+
+### Blocks
+
+We have built a collection of 30+ calendar blocks that you can use to build your own calendar components.
+
+See all calendar blocks in the [Blocks Library](/blocks/calendar) page.
+
+### Migrated from react-day-picker
+
+<Callout icon={<TriangleAlert />} tone="warning" title="Migrated from react-day-picker">
+We have replaced `react-day-picker` with our own headless calendar engine  -  [`@gentleduck/calendar`](/docs/packages/duck-calendar). The result is **75% smaller bundle** (~5 KB vs ~20 KB gzipped), zero external dependencies, full keyboard navigation, and complete ARIA compliance. See the [performance benchmarks](/docs/packages/duck-calendar#performance) for detailed comparisons.
+</Callout>
+
+### Date Picker
+
+You can use the `<Calendar>` component to build a date picker. See the [Date Picker](/docs/components/date-picker) page for more information.
 
 ## RTL Support
 

--- a/apps/duck-ui-docs/content/docs/components/card.mdx
+++ b/apps/duck-ui-docs/content/docs/components/card.mdx
@@ -78,8 +78,9 @@ import {
 </Card>
 ```
 
-<ComponentPreview name="card-2" description="A card with a form" />
+## Examples
 
+<ComponentPreview name="card-2" description="A card with a form" />
 
 ## Component Composition
 

--- a/apps/duck-ui-docs/content/docs/components/carousel.mdx
+++ b/apps/duck-ui-docs/content/docs/components/carousel.mdx
@@ -199,7 +199,34 @@ Use the `orientation` prop to set the orientation of the carousel.
 </Carousel>
 ```
 
-## Options
+### Slide Counter (API)
+
+<ComponentPreview
+  name="carousel-5"
+  title="Carousel"
+  description="A carousel with a slide counter."
+/>
+
+### Autoplay Plugin
+
+<ComponentPreview
+  name="carousel-6"
+  title="Carousel"
+  description="A carousel with the autoplay plugin."
+/>
+
+## Component Composition
+
+<MermaidDiagram chart={`graph TD
+    A[Carousel] --> B[CarouselContent]
+    B --> C[CarouselItem]
+    A --> D[CarouselPrevious]
+    A --> E[CarouselNext]
+`} />
+
+## Behavior
+
+### Options
 
 You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/api/options/) for more information.
 
@@ -218,15 +245,9 @@ You can pass options to the carousel using the `opts` prop. See the [Embla Carou
 </Carousel>
 ```
 
-## API
+### API
 
 Use a state and the `setApi` props to get an instance of the carousel API.
-
-<ComponentPreview
-  name="carousel-5"
-  title="Carousel"
-  description="A carousel with a slide counter."
-/>
 
 ```tsx showLineNumbers {1,4,22}
 import { type CarouselApi } from "@/components/ui/carousel"
@@ -261,7 +282,7 @@ export function Example() {
 }
 ```
 
-## Events
+### Events
 
 You can listen to events using the api instance from `setApi`.
 
@@ -295,7 +316,7 @@ export function Example() {
 
 See the [Embla Carousel docs](https://www.embla-carousel.com/api/events/) for more information on using events.
 
-## Plugins
+### Plugins
 
 You can use the `plugins` prop to add plugins to the carousel.
 
@@ -317,22 +338,7 @@ export function Example() {
 }
 ```
 
-<ComponentPreview
-  name="carousel-6"
-  title="Carousel"
-  description="A carousel with the autoplay plugin."
-/>
-
 See the [Embla Carousel docs](https://www.embla-carousel.com/api/plugins/) for more information on using plugins.
-
-## Component Composition
-
-<MermaidDiagram chart={`graph TD
-    A[Carousel] --> B[CarouselContent]
-    B --> C[CarouselItem]
-    A --> D[CarouselPrevious]
-    A --> E[CarouselNext]
-`} />
 
 ## RTL Support
 


### PR DESCRIPTION
Reorganize button, calendar, card, carousel MDX section order:

- **button**: Merged Features into Philosophy, moved RTL example to RTL Support section, removed "Props" from API Reference sub-headings
- **calendar**: Moved Blocks, Migration notice, and Date Picker info to Notes section, kept examples grouped
- **card**: Added Examples section heading for card-2 preview
- **carousel**: Moved carousel-5 and carousel-6 previews into Examples, restructured Options/API/Events/Plugins under Behavior, moved Component Composition before Behavior