### PR TITLE
perf(registry-ui): hoist motion options for Button, Card, Badge

### DIFF
--- a/packages/registry-ui/src/badge/badge.tsx
+++ b/packages/registry-ui/src/badge/badge.tsx
@@ -22,8 +22,10 @@ const Badge = React.forwardRef<
 })
 Badge.displayName = 'Badge'
 
+const MOTION_BADGE_OPTIONS = { transition: springBouncy } as const
+
 const MotionBadge = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof Badge>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset('scaleIn', MOTION_BADGE_OPTIONS)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div

--- a/packages/registry-ui/src/button/button.tsx
+++ b/packages/registry-ui/src/button/button.tsx
@@ -92,6 +92,8 @@ AnimationIcon.displayName = 'AnimationIcon'
 /*  MotionButton                                                       */
 /* ------------------------------------------------------------------ */
 
+const MOTION_BUTTON_OPTIONS = { transition: springBouncy } as const
+
 const MotionButton = React.forwardRef<
   HTMLButtonElement,
   Omit<ButtonProps, 'asChild' | 'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'>
@@ -113,7 +115,7 @@ const MotionButton = React.forwardRef<
     },
     ref,
   ) => {
-    const content = useMotionPreset('scaleIn', { transition: springBouncy })
+    const content = useMotionPreset('scaleIn', MOTION_BUTTON_OPTIONS)
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.button

--- a/packages/registry-ui/src/card/card.tsx
+++ b/packages/registry-ui/src/card/card.tsx
@@ -88,8 +88,13 @@ CardFooter.displayName = 'CardFooter'
 /*  MotionCard                                                         */
 /* ------------------------------------------------------------------ */
 
+const CARD_OPTIONS = { transition: springBouncy } as const
+const CARD_HEADER_OPTIONS = { transition: springBouncy, delay: 0.05 } as const
+const CARD_CONTENT_OPTIONS = { transition: springBouncy, delay: 0.1 } as const
+const CARD_FOOTER_OPTIONS = { transition: springBouncy, delay: 0.15 } as const
+
 const MotionCard = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof Card>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset('scaleIn', CARD_OPTIONS)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -101,7 +106,7 @@ const MotionCard = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutR
 MotionCard.displayName = 'MotionCard'
 
 const MotionCardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.05 })
+  const content = useMotionPreset('scaleIn', CARD_HEADER_OPTIONS)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -113,7 +118,7 @@ const MotionCardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<H
 MotionCardHeader.displayName = 'MotionCardHeader'
 
 const MotionCardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.1 })
+  const content = useMotionPreset('scaleIn', CARD_CONTENT_OPTIONS)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -125,7 +130,7 @@ const MotionCardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<
 MotionCardContent.displayName = 'MotionCardContent'
 
 const MotionCardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.15 })
+  const content = useMotionPreset('scaleIn', CARD_FOOTER_OPTIONS)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>


### PR DESCRIPTION
## Summary
- Hoist `useMotionPreset` option objects in `MotionButton`, `MotionCard` (+ `Header`/`Content`/`Footer`), and `MotionBadge` to module-level `as const` constants so a fresh object is no longer allocated on every render.
- Behavior and public API are unchanged — this is a pure allocation/referential-stability cleanup that helps the hook memoize its work.

## Test plan
- [x] `npx turbo run check-types --filter=@gentleduck/registry-ui --filter=@gentleduck/motion --filter=@gentleduck/registry-examples`
- [x] `cd apps/duck-ui-docs && node ../../packages/registry-build/dist/cli.mjs build`
- [x] `npx turbo run test --filter=@gentleduck/motion`