### PR TITLE
perf(registry-ui): hoist motion preset options for popover and menu contents

### DIFF
--- a/packages/registry-ui/src/badge/badge.tsx
+++ b/packages/registry-ui/src/badge/badge.tsx
@@ -22,8 +22,10 @@ const Badge = React.forwardRef<
 })
 Badge.displayName = 'Badge'
 
+const MOTION_BADGE_OPTIONS = { transition: springBouncy } as const
+
 const MotionBadge = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof Badge>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset('scaleIn', MOTION_BADGE_OPTIONS)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div

--- a/packages/registry-ui/src/button/button.tsx
+++ b/packages/registry-ui/src/button/button.tsx
@@ -92,6 +92,8 @@ AnimationIcon.displayName = 'AnimationIcon'
 /*  MotionButton                                                       */
 /* ------------------------------------------------------------------ */
 
+const MOTION_BUTTON_OPTIONS = { transition: springBouncy } as const
+
 const MotionButton = React.forwardRef<
   HTMLButtonElement,
   Omit<ButtonProps, 'asChild' | 'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'>
@@ -113,7 +115,7 @@ const MotionButton = React.forwardRef<
     },
     ref,
   ) => {
-    const content = useMotionPreset('scaleIn', { transition: springBouncy })
+    const content = useMotionPreset('scaleIn', MOTION_BUTTON_OPTIONS)
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.button

--- a/packages/registry-ui/src/card/card.tsx
+++ b/packages/registry-ui/src/card/card.tsx
@@ -88,8 +88,13 @@ CardFooter.displayName = 'CardFooter'
 /*  MotionCard                                                         */
 /* ------------------------------------------------------------------ */
 
+const CARD_OPTIONS = { transition: springBouncy } as const
+const CARD_HEADER_OPTIONS = { transition: springBouncy, delay: 0.05 } as const
+const CARD_CONTENT_OPTIONS = { transition: springBouncy, delay: 0.1 } as const
+const CARD_FOOTER_OPTIONS = { transition: springBouncy, delay: 0.15 } as const
+
 const MotionCard = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof Card>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset('scaleIn', CARD_OPTIONS)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -101,7 +106,7 @@ const MotionCard = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutR
 MotionCard.displayName = 'MotionCard'
 
 const MotionCardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.05 })
+  const content = useMotionPreset('scaleIn', CARD_HEADER_OPTIONS)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -113,7 +118,7 @@ const MotionCardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<H
 MotionCardHeader.displayName = 'MotionCardHeader'
 
 const MotionCardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.1 })
+  const content = useMotionPreset('scaleIn', CARD_CONTENT_OPTIONS)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -125,7 +130,7 @@ const MotionCardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<
 MotionCardContent.displayName = 'MotionCardContent'
 
 const MotionCardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.15 })
+  const content = useMotionPreset('scaleIn', CARD_FOOTER_OPTIONS)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/context-menu/context-menu.tsx
+++ b/packages/registry-ui/src/context-menu/context-menu.tsx
@@ -10,6 +10,9 @@ import { Check, ChevronRight, Circle } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
+const CONTENT_OPTIONS = { transition: springBouncy } as const
+const CONTENT_STYLE = { transformOrigin: 'top left' } as const
+
 const ContextMenu = ContextMenuPrimitive.Root
 ContextMenu.displayName = 'ContextMenu'
 
@@ -193,7 +196,7 @@ const MotionContextMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
 >(({ className, children, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset('scaleIn', CONTENT_OPTIONS)
   const isOpenRef = React.useRef(isOpen)
   isOpenRef.current = isOpen
   const shouldRender = useMotionMount(isOpen)
@@ -219,7 +222,7 @@ const MotionContextMenuContent = React.forwardRef<
               'z-50 max-h-(--gentleduck-context-menu-content-available-height) min-w-32 overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
               className,
             )}
-            style={{ transformOrigin: 'top left' }}
+            style={CONTENT_STYLE}
             initial={content.initial}
             animate={isOpen ? content.animate : { ...content.exit, pointerEvents: 'none' }}
             transition={content.transition}>
@@ -255,7 +258,7 @@ const MotionContextMenuSubContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
 >(({ className, children, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset('scaleIn', CONTENT_OPTIONS)
   const shouldRender = useMotionMount(isOpen)
 
   if (!shouldRender) return null

--- a/packages/registry-ui/src/dropdown-menu/dropdown-menu.tsx
+++ b/packages/registry-ui/src/dropdown-menu/dropdown-menu.tsx
@@ -10,6 +10,8 @@ import { Check, ChevronRight, Circle } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
+const CONTENT_OPTIONS = { transition: springBouncy } as const
+
 const DropdownMenu = DropdownMenuPrimitive.Root
 DropdownMenu.displayName = 'DropdownMenu'
 
@@ -198,7 +200,7 @@ const MotionDropdownMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 4, children, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset('scaleIn', CONTENT_OPTIONS)
   const shouldRender = useMotionMount(isOpen)
 
   if (!shouldRender) return null
@@ -247,7 +249,7 @@ const MotionDropdownMenuSubContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, children, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset('scaleIn', CONTENT_OPTIONS)
   const shouldRender = useMotionMount(isOpen)
 
   if (!shouldRender) return null

--- a/packages/registry-ui/src/popover/popover.tsx
+++ b/packages/registry-ui/src/popover/popover.tsx
@@ -9,6 +9,8 @@ import * as PopoverPrimitive from '@gentleduck/primitives/popover'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
+const CONTENT_OPTIONS = { transition: springSnappy } as const
+
 const Popover = PopoverPrimitive.Root
 Popover.displayName = 'Popover'
 
@@ -64,7 +66,7 @@ const MotionPopoverContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ className, align = 'center', sideOffset = 4, children, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const content = useMotionPreset('scaleIn', { transition: springSnappy })
+  const content = useMotionPreset('scaleIn', CONTENT_OPTIONS)
   const shouldRender = useMotionMount(isOpen)
 
   if (!shouldRender) return null


### PR DESCRIPTION
## Summary

- Hoist inline `{ transition }` objects passed to `useMotionPreset` into module-level `CONTENT_OPTIONS` constants in `MotionPopoverContent`, `MotionDropdownMenuContent`/`MotionDropdownMenuSubContent`, and `MotionContextMenuContent`/`MotionContextMenuSubContent`, so each content component stops reallocating its preset options object on every render.
- Also hoist the static `style={{ transformOrigin: 'top left' }}` on `MotionContextMenuContent` into a `CONTENT_STYLE` module constant to avoid the extra allocation and unnecessary style churn on re-renders.
- Behavior and public API are unchanged; this is a pure perf/bundle hygiene pass.

## Test plan

- [x] `npx turbo run check-types --filter=@gentleduck/registry-ui --filter=@gentleduck/motion --filter=@gentleduck/registry-examples`
- [x] `npx turbo run test --filter=@gentleduck/motion` (96 pass, 0 fail)
- [x] `cd apps/duck-ui-docs && node ../../packages/registry-build/dist/cli.mjs build`