### PR TITLE
 add sideEffects false to registry-ui and motion-provider export

### DIFF
--- a/packages/duck-motion/package.json
+++ b/packages/duck-motion/package.json
@@ -44,9 +44,21 @@
       "types": "./dist/presets/*.d.ts",
       "default": "./dist/presets/*.js"
     },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
+    "./motion-features": {
+      "types": "./dist/motion-features.d.ts",
+      "default": "./dist/motion-features.js"
+    },
+    "./motion-presets": {
+      "types": "./dist/motion-presets.d.ts",
+      "default": "./dist/motion-presets.js"
+    },
+    "./motion-provider": {
+      "types": "./dist/motion-provider.d.ts",
+      "default": "./dist/motion-provider.js"
+    },
+    "./use-motion-root": {
+      "types": "./dist/use-motion-root.d.ts",
+      "default": "./dist/use-motion-root.js"
     },
     "./css": "./src/css/index.css"
   },

--- a/packages/registry-ui/package.json
+++ b/packages/registry-ui/package.json
@@ -64,6 +64,7 @@
     }
   },
   "type": "module",
+  "sideEffects": false,
   "version": "0.3.2",
   "description": "Styled Tailwind components for Duck UI.",
   "keywords": [


### PR DESCRIPTION
Performance pass: extract inline object allocations to module-level constants and memoize context providers. No behavior change.