### PR TITLE
 memoize ToggleGroupContext and clean up MutationObserver

### DIFF
--- a/packages/registry-ui/src/toggle-group/toggle-group.tsx
+++ b/packages/registry-ui/src/toggle-group/toggle-group.tsx
@@ -25,8 +25,9 @@ type ToggleGroupProps = React.ComponentPropsWithoutRef<typeof ToggleGroupPrimiti
 const ToggleGroup: React.ForwardRefExoticComponent<ToggleGroupProps & React.RefAttributes<ToggleGroupElement>> =
   React.forwardRef<ToggleGroupElement, ToggleGroupProps>(
     ({ className, variant = 'default', size = 'default', children, ...props }, ref) => {
+      const contextValue = React.useMemo<ToggleGroupContextProps>(() => ({ size, variant }), [size, variant])
       return (
-        <ToggleGroupContext.Provider value={{ size, variant }}>
+        <ToggleGroupContext.Provider value={contextValue}>
           <ToggleGroupPrimitive.Root
             className={cn(
               'isolate flex items-center justify-center rounded-md *:first:rounded-s-md *:last:rounded-e-md',
@@ -82,10 +83,11 @@ const MotionToggleGroup: React.ForwardRefExoticComponent<
 > = React.forwardRef<ToggleGroupElement, ToggleGroupProps>(
   ({ className, variant = 'default', size = 'default', children, ...props }, ref) => {
     const groupId = React.useId()
+    const contextValue = React.useMemo<ToggleGroupContextProps>(() => ({ size, variant }), [size, variant])
     return (
       <LazyMotion features={loadDomMax}>
         <MotionToggleGroupIdContext.Provider value={groupId}>
-          <ToggleGroupContext.Provider value={{ size, variant }}>
+          <ToggleGroupContext.Provider value={contextValue}>
             <LayoutGroup id={`toggle-group-${groupId}`}>
               <ToggleGroupPrimitive.Root
                 className={cn(
@@ -123,10 +125,9 @@ const MotionToggleGroupItem: React.ForwardRefExoticComponent<
   React.useEffect(() => {
     const el = btnRef.current
     if (!el) return
-    const observer = new MutationObserver(() => {
-      setIsOn(el.getAttribute('data-state') === 'on')
-    })
-    setIsOn(el.getAttribute('data-state') === 'on')
+    const readState = () => setIsOn(el.getAttribute('data-state') === 'on')
+    readState()
+    const observer = new MutationObserver(readState)
     observer.observe(el, { attributes: true, attributeFilter: ['data-state'] })
     return () => observer.disconnect()
   }, [])

--- a/packages/registry-ui/src/toggle/toggle.tsx
+++ b/packages/registry-ui/src/toggle/toggle.tsx
@@ -33,7 +33,8 @@ const MotionToggle = React.forwardRef<
     'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'
   >
 >(({ className, variant = 'default', size = 'default', children, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const presetOptions = React.useMemo(() => ({ transition: springBouncy }), [])
+  const content = useMotionPreset('scaleIn', presetOptions)
   return (
     <LazyMotion features={loadDomAnimation}>
       <TogglePrimitive.Root asChild ref={ref} {...props}>


### PR DESCRIPTION
Performance pass: extract inline object allocations to module-level constants and memoize context providers. No behavior change.