### PR TITLE
 memoize useMotionPreset options in typography breadcrumb pagination command

### DIFF
--- a/packages/registry-ui/src/breadcrumb/breadcrumb.tsx
+++ b/packages/registry-ui/src/breadcrumb/breadcrumb.tsx
@@ -124,7 +124,8 @@ const MotionBreadcrumbItem = React.forwardRef<
     index?: number
   }
 >(({ className, index = 0, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springSnappy, delay: index * 0.035 })
+  const options = React.useMemo(() => ({ transition: springSnappy, delay: index * 0.035 }), [index])
+  const content = useMotionPreset('scaleIn', options)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.li
@@ -147,7 +148,8 @@ const MotionBreadcrumbSeparator = React.forwardRef<
     index?: number
   }
 >(({ children, className, index = 0, ...props }, ref) => {
-  const content = useMotionPreset('slideFromLeft', { transition: springSnappy, delay: index * 0.035 })
+  const options = React.useMemo(() => ({ transition: springSnappy, delay: index * 0.035 }), [index])
+  const content = useMotionPreset('slideFromLeft', options)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.li
@@ -171,7 +173,10 @@ const MotionBreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentP
   ({ className, children, ...props }, ref) => {
     let cursor = 0
     const injectIndex = (child: React.ReactNode): React.ReactNode => {
-      if (React.isValidElement(child) && (child.type === MotionBreadcrumbItem || child.type === MotionBreadcrumbSeparator)) {
+      if (
+        React.isValidElement(child) &&
+        (child.type === MotionBreadcrumbItem || child.type === MotionBreadcrumbSeparator)
+      ) {
         const injected = React.cloneElement(child as React.ReactElement<{ index?: number }>, {
           index: cursor++,
         })

--- a/packages/registry-ui/src/command/command.tsx
+++ b/packages/registry-ui/src/command/command.tsx
@@ -122,7 +122,8 @@ const MotionCommandItem = React.forwardRef<
     'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'
   > & { index?: number }
 >(({ className, index = 0, children, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.03 })
+  const options = React.useMemo(() => ({ transition: springBouncy, delay: index * 0.03 }), [index])
+  const content = useMotionPreset('scaleIn', options)
   return (
     <LazyMotion features={loadDomAnimation}>
       <CommandPrimitive.Item asChild ref={ref} {...props}>

--- a/packages/registry-ui/src/pagination/pagination.tsx
+++ b/packages/registry-ui/src/pagination/pagination.tsx
@@ -208,7 +208,8 @@ const MotionPaginationLink = React.forwardRef<
   HTMLAnchorElement,
   Omit<PaginationLinkProps, 'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'> & { index?: number }
 >(({ className, isActive, size = 'icon', index = 0, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+  const options = React.useMemo(() => ({ transition: springBouncy, delay: index * 0.05 }), [index])
+  const content = useMotionPreset('scaleIn', options)
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.a

--- a/packages/registry-ui/src/typography/typography.tsx
+++ b/packages/registry-ui/src/typography/typography.tsx
@@ -158,10 +158,8 @@ TypographyTd.displayName = 'TypographyTd'
 type MotionIndexProps = { index?: number }
 
 function useTypographyMotion(index: number) {
-  return useMotionPreset('slideUp', {
-    transition: springBouncy,
-    delay: index * 0.05,
-  })
+  const options = React.useMemo(() => ({ transition: springBouncy, delay: index * 0.05 }), [index])
+  return useMotionPreset('slideUp', options)
 }
 
 type MotionHeadingProps = Omit<


### PR DESCRIPTION
Performance pass: extract inline object allocations to module-level constants and memoize context providers. No behavior change.