### PR TITLE
 extract static preset options in input and label

### DIFF
--- a/packages/registry-ui/src/input/input.tsx
+++ b/packages/registry-ui/src/input/input.tsx
@@ -50,7 +50,8 @@ Input.displayName = 'Input'
 
 const MotionInput = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'> & { index?: number }>(
   ({ index = 0, ...props }, ref) => {
-    const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+    const options = React.useMemo(() => ({ transition: springBouncy, delay: index * 0.05 }), [index])
+    const content = useMotionPreset('scaleIn', options)
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/label/label.tsx
+++ b/packages/registry-ui/src/label/label.tsx
@@ -32,7 +32,8 @@ Label.displayName = 'Label'
 
 const MotionLabel = React.forwardRef<HTMLLabelElement, LabelProps & { index?: number }>(
   ({ index = 0, ...props }, ref) => {
-    const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+    const options = React.useMemo(() => ({ transition: springBouncy, delay: index * 0.05 }), [index])
+    const content = useMotionPreset('scaleIn', options)
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.div initial={content.initial} animate={content.animate} transition={content.transition}>


### PR DESCRIPTION
Performance pass: extract inline object allocations to module-level constants and memoize context providers. No behavior change.