### PR TITLE
perf(registry-ui): memoize accordion and tabs context providers, extract tabs variants constant, memoize sheet overlay

### DIFF
--- a/packages/registry-ui/src/accordion/accordion.tsx
+++ b/packages/registry-ui/src/accordion/accordion.tsx
@@ -12,6 +12,8 @@ import { ChevronDown } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
+const TRIGGER_OPTIONS = { transition: springBouncy } as const
+
 const AccordionContext = React.createContext<{
   value: string[]
   readonly onValueChange?: (value: string | string[]) => void
@@ -131,13 +133,16 @@ const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
 
     return (
       <AccordionContext.Provider
-        value={{
-          onItemChange: handleAccordionItemChange,
-          onValueChange: onValueChange as never,
-          renderOnce,
-          value: currentValues,
-          wrapperRef,
-        }}>
+        value={React.useMemo(
+          () => ({
+            onItemChange: handleAccordionItemChange,
+            onValueChange: onValueChange as never,
+            renderOnce,
+            value: currentValues,
+            wrapperRef,
+          }),
+          [handleAccordionItemChange, onValueChange, renderOnce, currentValues, wrapperRef],
+        )}>
         <div
           className={cn('min-w-100 [interpolate-size:allow-keywords]', className)}
           dir={direction}
@@ -267,7 +272,8 @@ const MotionAccordionItem = React.forwardRef<
   const isActive = _value.includes(value as string)
   const detailsRef = React.useRef<HTMLDetailsElement>(null)
   const direction = useDirection(dir as Direction)
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+  const presetOptions = React.useMemo(() => ({ transition: springBouncy, delay: index * 0.05 }), [index])
+  const content = useMotionPreset('scaleIn', presetOptions)
 
   // Keep <details> always open so motion can animate the content height.
   // The accordion root's onItemChange sets .open on DOM elements directly,
@@ -334,7 +340,7 @@ const MotionAccordionTrigger = React.forwardRef<
   React.HTMLProps<HTMLElement> & { icon?: React.ReactNode; value?: string }
 >(({ className, children, icon, value, ...props }, ref) => {
   const { isActive } = React.useContext(MotionAccordionItemContext)
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset('scaleIn', TRIGGER_OPTIONS)
 
   return (
     <summary

--- a/packages/registry-ui/src/sheet/sheet.tsx
+++ b/packages/registry-ui/src/sheet/sheet.tsx
@@ -13,6 +13,8 @@ import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 import { sheetVariants } from './sheet.constants'
 
+const OVERLAY_OPTIONS = {} as const
+
 const Sheet = SheetPrimitive.Root
 Sheet.displayName = 'Sheet'
 
@@ -123,7 +125,7 @@ const MotionSheetContent = React.forwardRef<
   SheetContentProps & { closeText?: string; hideClose?: boolean }
 >(({ side = 'right', className, children, closeText = 'Close', hideClose = false, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const overlay = useMotionPreset('fadeIn')
+  const overlay = useMotionPreset('fadeIn', OVERLAY_OPTIONS)
   const slide = React.useMemo(() => createSlideEdge(side ?? 'right'), [side])
   // Sheet uses tweenSlow (300ms) for its slide, so give the exit a bit more
   // room before unmounting.

--- a/packages/registry-ui/src/tabs/tabs.tsx
+++ b/packages/registry-ui/src/tabs/tabs.tsx
@@ -10,6 +10,13 @@ import { MountMinimal } from '@gentleduck/primitives/mount'
 import { AnimatePresence, LayoutGroup, LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
+const BLUR = `blur(${blurLight}px)`
+const MOTION_TABS_VARIANTS = {
+  enter: (dir: number) => ({ opacity: 0, x: `${dir * 8}%`, scale: 0.98, filter: BLUR }),
+  center: { opacity: 1, x: 0, scale: 1, filter: 'blur(0px)' },
+  exit: (dir: number) => ({ opacity: 0, x: `${dir * -8}%`, scale: 0.98, filter: BLUR }),
+} as const
+
 export function useTabs() {
   const context = React.useContext(TabsContext)
   if (context === null) {
@@ -201,7 +208,7 @@ const MotionTabs = React.forwardRef<HTMLDivElement, TabsProps>(
     const motionCtx = React.useMemo(() => ({ direction: motionDir, registerTrigger }), [motionDir, registerTrigger])
 
     return (
-      <TabsContext.Provider value={{ activeItem, setActiveItem: wrappedSetActiveItem, tabsId }}>
+      <TabsContext.Provider value={React.useMemo(() => ({ activeItem, setActiveItem: wrappedSetActiveItem, tabsId }), [activeItem, wrappedSetActiveItem, tabsId])}>
         <MotionTabsContext.Provider value={motionCtx}>
           <LazyMotion features={loadDomMax}>
             <div {...props} data-slot="tabs" dir={resolvedDir} ref={ref}>
@@ -329,30 +336,16 @@ const MotionTabsContents = React.forwardRef<
         mode="popLayout"
         initial={false}
         custom={direction}
-        onExitComplete={() => {
+        onExitComplete={React.useCallback(() => {
           if (containerRef.current) {
             setHeight(containerRef.current.scrollHeight)
           }
-        }}>
+        }, [])}>
         {activeChild && React.isValidElement(activeChild) ? (
           <m.div
             key={activeItem}
             custom={direction}
-            variants={{
-              enter: (dir: number) => ({
-                opacity: 0,
-                x: `${dir * 8}%`,
-                scale: 0.98,
-                filter: `blur(${blurLight}px)`,
-              }),
-              center: { opacity: 1, x: 0, scale: 1, filter: 'blur(0px)' },
-              exit: (dir: number) => ({
-                opacity: 0,
-                x: `${dir * -8}%`,
-                scale: 0.98,
-                filter: `blur(${blurLight}px)`,
-              }),
-            }}
+            variants={MOTION_TABS_VARIANTS}
             initial="enter"
             animate="center"
             exit="exit"


### PR DESCRIPTION
Performance pass for the three units that rate-limited before completing. Memoizes AccordionContext and TabsContext provider values, extracts the inline tabs content variants to a module constant, wraps onExitComplete in useCallback, and extracts the sheet overlay preset options. No behavior change.