### PR TITLE
perf: migrate useMotionPreset to direct preset imports for tree-shaking

### DIFF
--- a/packages/duck-motion/src/motion-presets.tsx
+++ b/packages/duck-motion/src/motion-presets.tsx
@@ -106,10 +106,30 @@ export async function resolveMotionPreset(
   return buildResult(preset, false, options)
 }
 
-/** Sync hook for React components. Memoizes the result to avoid creating new objects on every render. */
-export function useMotionPreset(name: MotionPresetName, options?: UseMotionPresetOptions): MotionPresetResult {
+/**
+ * Sync hook for React components. Memoizes the result to avoid creating new
+ * objects on every render.
+ *
+ * Accepts either a preset name (string lookup — convenient but bundles all
+ * presets) or a preset object directly (tree-shakeable — only the imported
+ * preset is bundled). Prefer the object form for optimal bundle size:
+ *
+ * ```tsx
+ * import { scaleIn } from '@gentleduck/motion/presets/scale-in'
+ * const content = useMotionPreset(scaleIn, { transition: springBouncy })
+ * ```
+ */
+export function useMotionPreset(
+  nameOrPreset: MotionPresetName | MotionPreset,
+  options?: UseMotionPresetOptions,
+): MotionPresetResult {
   const reduced = useDuckReducedMotion()
-  const preset = options?.direction ? createDirectionalPreset(options.direction) : presetMap[name]
+  const preset =
+    options?.direction
+      ? createDirectionalPreset(options.direction)
+      : typeof nameOrPreset === 'string'
+        ? presetMap[nameOrPreset]
+        : nameOrPreset
   const result = buildResult(preset, reduced, options)
 
   // biome-ignore lint/correctness/useHookAtTopLevel: guarded for non-React environments (tests)
@@ -118,7 +138,7 @@ export function useMotionPreset(name: MotionPresetName, options?: UseMotionPrese
       return React.useMemo(
         () => buildResult(preset, reduced, options),
         [
-          name,
+          nameOrPreset,
           reduced,
           options?.direction,
           options?.delay,

--- a/packages/registry-ui/src/accordion/accordion.tsx
+++ b/packages/registry-ui/src/accordion/accordion.tsx
@@ -8,6 +8,7 @@ import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { duckMotionDuration, tweenExpand } from '@gentleduck/motion/transitions/tweens'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
 import { Mount } from '@gentleduck/primitives/mount'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { ChevronDown } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -267,7 +268,7 @@ const MotionAccordionItem = React.forwardRef<
   const isActive = _value.includes(value as string)
   const detailsRef = React.useRef<HTMLDetailsElement>(null)
   const direction = useDirection(dir as Direction)
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.05 })
 
   // Keep <details> always open so motion can animate the content height.
   // The accordion root's onItemChange sets .open on DOM elements directly,
@@ -334,7 +335,7 @@ const MotionAccordionTrigger = React.forwardRef<
   React.HTMLProps<HTMLElement> & { icon?: React.ReactNode; value?: string }
 >(({ className, children, icon, value, ...props }, ref) => {
   const { isActive } = React.useContext(MotionAccordionItemContext)
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
 
   return (
     <summary

--- a/packages/registry-ui/src/alert-dialog/alert-dialog.tsx
+++ b/packages/registry-ui/src/alert-dialog/alert-dialog.tsx
@@ -6,6 +6,8 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springStiff } from '@gentleduck/motion/transitions/springs'
 import { MotionRootContext, useMotionContent, useMotionMount, useMotionRoot } from '@gentleduck/motion/use-motion-root'
 import * as AlertDialogPrimitive from '@gentleduck/primitives/alert-dialog'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
+import { fadeIn } from '@gentleduck/motion/presets/fade-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 import { buttonVariants } from '../button'
@@ -127,8 +129,8 @@ const MotionAlertDialogContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const overlay = useMotionPreset('fadeIn')
-  const content = useMotionPreset('scaleIn', {
+  const overlay = useMotionPreset(fadeIn)
+  const content = useMotionPreset(scaleIn, {
     transition: springStiff,
   })
   const shouldRender = useMotionMount(isOpen)

--- a/packages/registry-ui/src/alert/alert.tsx
+++ b/packages/registry-ui/src/alert/alert.tsx
@@ -6,6 +6,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
 import type { VariantProps } from '@gentleduck/variants'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 import { alertVariants } from './alert.constants'
@@ -67,7 +68,7 @@ const MotionAlert = React.forwardRef<
   >
 >(({ className, variant, dir, ...props }, ref) => {
   const direction = useDirection(dir as Direction)
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div
@@ -90,7 +91,7 @@ const MotionAlertTitle = React.forwardRef<
   HTMLDivElement,
   Omit<React.HTMLAttributes<HTMLDivElement>, 'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'>
 >(({ className, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.1 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: 0.1 })
   return (
     <m.div
       ref={ref}
@@ -109,7 +110,7 @@ const MotionAlertDescription = React.forwardRef<
   HTMLDivElement,
   Omit<React.HTMLAttributes<HTMLDivElement>, 'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'>
 >(({ className, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.18 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: 0.18 })
   return (
     <m.div
       ref={ref}

--- a/packages/registry-ui/src/aspect-ratio/aspect-ratio.tsx
+++ b/packages/registry-ui/src/aspect-ratio/aspect-ratio.tsx
@@ -6,6 +6,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
 import { Slot } from '@gentleduck/primitives/slot'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import React from 'react'
 
@@ -36,7 +37,7 @@ const MotionAspectRatio = React.forwardRef<
   React.ComponentRef<typeof AspectRatio>,
   React.ComponentPropsWithoutRef<typeof AspectRatio>
 >((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/avatar/avatar.tsx
+++ b/packages/registry-ui/src/avatar/avatar.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import * as AvatarPrimitive from '@gentleduck/primitives/avatar'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -85,7 +86,7 @@ AvatarGroup.displayName = 'AvatarGroup'
 
 const MotionAvatar = React.forwardRef<React.ComponentRef<typeof Avatar>, React.ComponentPropsWithoutRef<typeof Avatar>>(
   (props, ref) => {
-    const content = useMotionPreset('scaleIn', { transition: springBouncy })
+    const content = useMotionPreset(scaleIn, { transition: springBouncy })
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.div
@@ -105,7 +106,7 @@ const MotionAvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
   ({ imgs, maxVisible = 3, className, ...props }, ref) => {
     const visibleImgs = imgs.slice(0, maxVisible)
     const overflowCount = imgs.length > maxVisible ? imgs.length - maxVisible : 0
-    const content = useMotionPreset('scaleIn', { transition: springBouncy })
+    const content = useMotionPreset(scaleIn, { transition: springBouncy })
 
     return (
       <LazyMotion features={loadDomAnimation}>

--- a/packages/registry-ui/src/badge/badge.tsx
+++ b/packages/registry-ui/src/badge/badge.tsx
@@ -6,6 +6,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { Slot } from '@gentleduck/primitives/slot'
 import type { VariantProps } from '@gentleduck/variants'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 import { badgeVariants } from './badge.constants'
@@ -23,7 +24,7 @@ const Badge = React.forwardRef<
 Badge.displayName = 'Badge'
 
 const MotionBadge = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof Badge>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div

--- a/packages/registry-ui/src/breadcrumb/breadcrumb.tsx
+++ b/packages/registry-ui/src/breadcrumb/breadcrumb.tsx
@@ -6,6 +6,8 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springSnappy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
 import { Slot } from '@gentleduck/primitives/slot'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
+import { slideFromLeft } from '@gentleduck/motion/presets/slide-from-left'
 import { ChevronRight, MoreHorizontal } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -124,7 +126,7 @@ const MotionBreadcrumbItem = React.forwardRef<
     index?: number
   }
 >(({ className, index = 0, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springSnappy, delay: index * 0.035 })
+  const content = useMotionPreset(scaleIn, { transition: springSnappy, delay: index * 0.035 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.li
@@ -147,7 +149,7 @@ const MotionBreadcrumbSeparator = React.forwardRef<
     index?: number
   }
 >(({ children, className, index = 0, ...props }, ref) => {
-  const content = useMotionPreset('slideFromLeft', { transition: springSnappy, delay: index * 0.035 })
+  const content = useMotionPreset(slideFromLeft, { transition: springSnappy, delay: index * 0.035 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.li

--- a/packages/registry-ui/src/button-group/button-group.tsx
+++ b/packages/registry-ui/src/button-group/button-group.tsx
@@ -7,6 +7,7 @@ import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
 import { Slot } from '@gentleduck/primitives/slot'
 import type { VariantProps } from '@gentleduck/variants'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 import { Separator } from '../separator'
@@ -81,7 +82,7 @@ const MotionButtonGroup = React.forwardRef<
   >
 >(({ className, orientation = 'horizontal', dir, ...props }, ref) => {
   const direction = useDirection(dir as Direction)
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       {/* biome-ignore lint/a11y/useSemanticElements: group role is semantically correct for button groups */}

--- a/packages/registry-ui/src/button/button.tsx
+++ b/packages/registry-ui/src/button/button.tsx
@@ -11,6 +11,7 @@ import {
 } from '@gentleduck/motion/presets/content'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { Slot, Slottable } from '@gentleduck/primitives/slot'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { Loader } from 'lucide-react'
 import { AnimatePresence, LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -113,7 +114,7 @@ const MotionButton = React.forwardRef<
     },
     ref,
   ) => {
-    const content = useMotionPreset('scaleIn', { transition: springBouncy })
+    const content = useMotionPreset(scaleIn, { transition: springBouncy })
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.button

--- a/packages/registry-ui/src/calendar/calendar.tsx
+++ b/packages/registry-ui/src/calendar/calendar.tsx
@@ -9,6 +9,7 @@ import { blurLight } from '@gentleduck/motion/transitions/blur'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { tweenExpand } from '@gentleduck/motion/transitions/tweens'
 import { useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import { AnimatePresence, LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -320,7 +321,7 @@ const MotionCalendar = React.forwardRef<HTMLDivElement, CalendarProps>(
       original()
     }
 
-    const calContent = useMotionPreset('scaleIn', { transition: springBouncy })
+    const calContent = useMotionPreset(scaleIn, { transition: springBouncy })
 
     return (
       <LazyMotion features={loadDomAnimation}>

--- a/packages/registry-ui/src/card/card.tsx
+++ b/packages/registry-ui/src/card/card.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -89,7 +90,7 @@ CardFooter.displayName = 'CardFooter'
 /* ------------------------------------------------------------------ */
 
 const MotionCard = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof Card>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -101,7 +102,7 @@ const MotionCard = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutR
 MotionCard.displayName = 'MotionCard'
 
 const MotionCardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.05 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: 0.05 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -113,7 +114,7 @@ const MotionCardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<H
 MotionCardHeader.displayName = 'MotionCardHeader'
 
 const MotionCardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.1 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: 0.1 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -125,7 +126,7 @@ const MotionCardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<
 MotionCardContent.displayName = 'MotionCardContent'
 
 const MotionCardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.15 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: 0.15 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/checkbox/checkbox.tsx
+++ b/packages/registry-ui/src/checkbox/checkbox.tsx
@@ -8,6 +8,7 @@ import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { checkersStylePattern } from '@gentleduck/motion/variants'
 import { useSvgIndicator } from '@gentleduck/primitives/checkers'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 import { Label } from '../label'
@@ -180,7 +181,7 @@ const MotionCheckboxWithLabel = React.forwardRef<
   Omit<CheckboxWithLabelProps, 'ref'> & { index?: number }
 >(({ id, _checkbox, _label, className, index = 0 }, ref) => {
   const { className: labelClassName, ...labelProps } = _label
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.05 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div

--- a/packages/registry-ui/src/command/command.tsx
+++ b/packages/registry-ui/src/command/command.tsx
@@ -6,6 +6,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import * as CommandPrimitive from '@gentleduck/primitives/command'
 import { useKeyCommands } from '@gentleduck/vim/react'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { Search } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -122,7 +123,7 @@ const MotionCommandItem = React.forwardRef<
     'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'
   > & { index?: number }
 >(({ className, index = 0, children, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.03 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.03 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <CommandPrimitive.Item asChild ref={ref} {...props}>

--- a/packages/registry-ui/src/context-menu/context-menu.tsx
+++ b/packages/registry-ui/src/context-menu/context-menu.tsx
@@ -6,6 +6,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { MotionRootContext, useMotionContent, useMotionMount, useMotionRoot } from '@gentleduck/motion/use-motion-root'
 import * as ContextMenuPrimitive from '@gentleduck/primitives/context-menu'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { Check, ChevronRight, Circle } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -193,7 +194,7 @@ const MotionContextMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
 >(({ className, children, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   const isOpenRef = React.useRef(isOpen)
   isOpenRef.current = isOpen
   const shouldRender = useMotionMount(isOpen)
@@ -255,7 +256,7 @@ const MotionContextMenuSubContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
 >(({ className, children, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   const shouldRender = useMotionMount(isOpen)
 
   if (!shouldRender) return null

--- a/packages/registry-ui/src/dialog/dialog.tsx
+++ b/packages/registry-ui/src/dialog/dialog.tsx
@@ -6,6 +6,8 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { MotionRootContext, useMotionContent, useMotionMount, useMotionRoot } from '@gentleduck/motion/use-motion-root'
 import * as DialogPrimitive from '@gentleduck/primitives/dialog'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
+import { fadeIn } from '@gentleduck/motion/presets/fade-in'
 import { X } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -128,8 +130,8 @@ const MotionDialogContent = React.forwardRef<
   }
 >(({ className, children, closeText = 'Close', hideClose = false, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const overlay = useMotionPreset('fadeIn', { transition: springBouncy })
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const overlay = useMotionPreset(fadeIn, { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   const shouldRender = useMotionMount(isOpen)
 
   if (!shouldRender) return null

--- a/packages/registry-ui/src/dropdown-menu/dropdown-menu.tsx
+++ b/packages/registry-ui/src/dropdown-menu/dropdown-menu.tsx
@@ -6,6 +6,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { MotionRootContext, useMotionContent, useMotionMount, useMotionRoot } from '@gentleduck/motion/use-motion-root'
 import * as DropdownMenuPrimitive from '@gentleduck/primitives/dropdown-menu'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { Check, ChevronRight, Circle } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -198,7 +199,7 @@ const MotionDropdownMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 4, children, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   const shouldRender = useMotionMount(isOpen)
 
   if (!shouldRender) return null
@@ -247,7 +248,7 @@ const MotionDropdownMenuSubContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, children, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   const shouldRender = useMotionMount(isOpen)
 
   if (!shouldRender) return null

--- a/packages/registry-ui/src/empty/empty.tsx
+++ b/packages/registry-ui/src/empty/empty.tsx
@@ -6,6 +6,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
 import type { VariantProps } from '@gentleduck/variants'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import React from 'react'
 import { emptyMediaVariants } from './empty.constants'
@@ -94,7 +95,7 @@ EmptyContent.displayName = 'EmptyContent'
 /* ------------------------------------------------------------------ */
 
 const MotionEmpty = React.forwardRef<HTMLDivElement, React.ComponentProps<'div'>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -109,7 +110,7 @@ const MotionEmptyMedia = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<'div'> & VariantProps<typeof emptyMediaVariants>
 >((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.05 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: 0.05 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -121,7 +122,7 @@ const MotionEmptyMedia = React.forwardRef<
 MotionEmptyMedia.displayName = 'MotionEmptyMedia'
 
 const MotionEmptyTitle = React.forwardRef<HTMLDivElement, React.ComponentProps<'div'>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.1 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: 0.1 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -133,7 +134,7 @@ const MotionEmptyTitle = React.forwardRef<HTMLDivElement, React.ComponentProps<'
 MotionEmptyTitle.displayName = 'MotionEmptyTitle'
 
 const MotionEmptyDescription = React.forwardRef<HTMLDivElement, React.ComponentProps<'p'>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.15 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: 0.15 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -145,7 +146,7 @@ const MotionEmptyDescription = React.forwardRef<HTMLDivElement, React.ComponentP
 MotionEmptyDescription.displayName = 'MotionEmptyDescription'
 
 const MotionEmptyContent = React.forwardRef<HTMLDivElement, React.ComponentProps<'div'>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.2 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: 0.2 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/field/field.tsx
+++ b/packages/registry-ui/src/field/field.tsx
@@ -6,6 +6,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
 import type { VariantProps } from '@gentleduck/variants'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import React, { useMemo } from 'react'
 import { Label } from '../label'
@@ -230,7 +231,7 @@ const MotionField = React.forwardRef<
   HTMLDivElement,
   React.ComponentPropsWithoutRef<'div'> & VariantProps<typeof fieldVariants> & { index?: number }
 >(({ index = 0, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.05 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -242,7 +243,7 @@ const MotionField = React.forwardRef<
 MotionField.displayName = 'MotionField'
 
 const MotionFieldGroup = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -257,7 +258,7 @@ const MotionFieldError = React.forwardRef<
   HTMLDivElement,
   React.ComponentPropsWithoutRef<'div'> & { errors?: Array<{ message?: string } | undefined> }
 >((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: 0.05 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: 0.05 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/input-group/input-group.tsx
+++ b/packages/registry-ui/src/input-group/input-group.tsx
@@ -6,6 +6,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
 import { cva, type VariantProps } from '@gentleduck/variants'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 import { Button } from '../button'
@@ -180,7 +181,7 @@ InputGroupTextarea.displayName = 'InputGroupTextarea'
 
 const MotionInputGroup = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'> & { index?: number }>(
   ({ index = 0, ...props }, ref) => {
-    const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+    const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.05 })
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/input-otp/input-otp.tsx
+++ b/packages/registry-ui/src/input-otp/input-otp.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import * as InputOTPPrimitive from '@gentleduck/primitives/input-otp'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { Dot } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -75,7 +76,7 @@ const MotionInputOTP = React.forwardRef<
   React.ComponentRef<typeof InputOTPPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof InputOTPPrimitive.Root>
 >((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/input/input.tsx
+++ b/packages/registry-ui/src/input/input.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -50,7 +51,7 @@ Input.displayName = 'Input'
 
 const MotionInput = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'> & { index?: number }>(
   ({ index = 0, ...props }, ref) => {
-    const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+    const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.05 })
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/item/item.tsx
+++ b/packages/registry-ui/src/item/item.tsx
@@ -7,6 +7,7 @@ import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
 import { Slot } from '@gentleduck/primitives/slot'
 import { cva, type VariantProps } from '@gentleduck/variants'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 import { Separator } from '../separator'
@@ -186,7 +187,7 @@ const MotionItem = React.forwardRef<
   HTMLDivElement,
   React.ComponentPropsWithoutRef<'div'> & VariantProps<typeof itemVariants> & { asChild?: boolean; index?: number }
 >(({ index = 0, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.04 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.04 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -198,7 +199,7 @@ const MotionItem = React.forwardRef<
 MotionItem.displayName = 'MotionItem'
 
 const MotionItemGroup = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>((props, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/json-editor/json-editor.tsx
+++ b/packages/registry-ui/src/json-editor/json-editor.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { Portal } from '@gentleduck/primitives/portal'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { Maximize } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -450,7 +451,7 @@ JsonTextareaField.displayName = 'JsonTextareaField'
 export function MotionJsonTextareaField<TFieldValues extends FieldValues>(
   props: JsonTextareaFieldProps<TFieldValues>,
 ): React.JSX.Element {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/kbd/kbd.tsx
+++ b/packages/registry-ui/src/kbd/kbd.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -44,7 +45,7 @@ KbdGroup.displayName = 'KbdGroup'
 
 const MotionKbd = React.forwardRef<HTMLElement, React.ComponentPropsWithoutRef<'kbd'> & { index?: number }>(
   ({ index = 0, ...props }, ref) => {
-    const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.03 })
+    const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.03 })
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.div

--- a/packages/registry-ui/src/label/label.tsx
+++ b/packages/registry-ui/src/label/label.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -32,7 +33,7 @@ Label.displayName = 'Label'
 
 const MotionLabel = React.forwardRef<HTMLLabelElement, LabelProps & { index?: number }>(
   ({ index = 0, ...props }, ref) => {
-    const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+    const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.05 })
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/menubar/menubar.tsx
+++ b/packages/registry-ui/src/menubar/menubar.tsx
@@ -6,6 +6,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { AnimVariants } from '@gentleduck/motion/variants'
 import * as MenubarPrimitive from '@gentleduck/primitives/menubar'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { Check, ChevronRight, Circle } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -212,7 +213,7 @@ const MotionMenubarContent = React.forwardRef<
   React.ComponentRef<typeof MenubarPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Content>
 >(({ className, align = 'start', alignOffset = -4, sideOffset = 8, children, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <MenubarPrimitive.Portal>
       <MenubarPrimitive.Content

--- a/packages/registry-ui/src/navigation-menu/navigation-menu.tsx
+++ b/packages/registry-ui/src/navigation-menu/navigation-menu.tsx
@@ -4,6 +4,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import * as NavigationMenuPrimitive from '@gentleduck/primitives/navigation-menu'
 import { cva } from '@gentleduck/variants'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { ChevronDown } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -149,7 +150,7 @@ const MotionNavigationMenu = React.forwardRef<
     viewport?: boolean
   }
 >(({ className, children, viewport = true, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>

--- a/packages/registry-ui/src/pagination/pagination.tsx
+++ b/packages/registry-ui/src/pagination/pagination.tsx
@@ -5,6 +5,7 @@ import { tapScale } from '@gentleduck/motion/presets/content'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
 import * as PaginationPrimitive from '@gentleduck/primitives/pagination'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import {
   ChevronLeft,
   ChevronLeftIcon,
@@ -188,7 +189,7 @@ const MotionPagination = React.forwardRef<
   React.ComponentRef<typeof PaginationPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof PaginationPrimitive.Root>
 >(({ className, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div initial={content.initial} animate={content.animate} transition={content.transition}>
@@ -208,7 +209,7 @@ const MotionPaginationLink = React.forwardRef<
   HTMLAnchorElement,
   Omit<PaginationLinkProps, 'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'> & { index?: number }
 >(({ className, isActive, size = 'icon', index = 0, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.05 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.a

--- a/packages/registry-ui/src/popover/popover.tsx
+++ b/packages/registry-ui/src/popover/popover.tsx
@@ -6,6 +6,7 @@ import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springSnappy } from '@gentleduck/motion/transitions/springs'
 import { MotionRootContext, useMotionContent, useMotionMount, useMotionRoot } from '@gentleduck/motion/use-motion-root'
 import * as PopoverPrimitive from '@gentleduck/primitives/popover'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -64,7 +65,7 @@ const MotionPopoverContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ className, align = 'center', sideOffset = 4, children, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const content = useMotionPreset('scaleIn', { transition: springSnappy })
+  const content = useMotionPreset(scaleIn, { transition: springSnappy })
   const shouldRender = useMotionMount(isOpen)
 
   if (!shouldRender) return null

--- a/packages/registry-ui/src/preview-panel/preview-panel.tsx
+++ b/packages/registry-ui/src/preview-panel/preview-panel.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { Minus, Plus, RotateCcw } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -501,7 +502,7 @@ const MotionPreviewPanel = React.forwardRef<
   ) => {
     const containerRef = useRef<HTMLDivElement>(null)
     const contentRef = useRef<HTMLDivElement>(null)
-    const content = useMotionPreset('scaleIn', { transition: springBouncy })
+    const content = useMotionPreset(scaleIn, { transition: springBouncy })
 
     const s = useRef({
       zoom: initialZoom,

--- a/packages/registry-ui/src/radio-group/radio-group.tsx
+++ b/packages/registry-ui/src/radio-group/radio-group.tsx
@@ -7,6 +7,7 @@ import { checkerBounce, contentTransition } from '@gentleduck/motion/presets/con
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { useSvgIndicator } from '@gentleduck/primitives/checkers'
 import * as RadioGroupPrimitive from '@gentleduck/primitives/radio-group'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -107,7 +108,7 @@ const MotionRadioGroupItem = React.forwardRef<
     index?: number
   }
 >(({ className, indicator, checkedIndicator, children, textValue, index = 0, onClick, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.05 })
   const [bounce, setBounce] = React.useState(false)
   const { indicatorReady, checkedIndicatorReady, inputStyle, SvgIndicator } = useSvgIndicator({
     checkedIndicator,

--- a/packages/registry-ui/src/resizable/resizable.tsx
+++ b/packages/registry-ui/src/resizable/resizable.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { GripVertical } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import React from 'react'
@@ -69,7 +70,7 @@ const MotionResizablePanelGroup = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ResizablePrimitive.Group> & { dir?: Direction }
 >(({ className, dir, ...props }, ref) => {
   const direction = useDirection(dir as Direction)
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div

--- a/packages/registry-ui/src/scroll-area/scroll-area.tsx
+++ b/packages/registry-ui/src/scroll-area/scroll-area.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -42,7 +43,7 @@ const MotionScrollArea = React.forwardRef<
   Omit<ScrollAreaProps, 'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'>
 >(({ children, className, viewportClassName, viewportRef, style, dir, ...props }, ref) => {
   const direction = useDirection(dir as Direction)
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div

--- a/packages/registry-ui/src/select/select.tsx
+++ b/packages/registry-ui/src/select/select.tsx
@@ -7,6 +7,7 @@ import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { MotionRootContext, useMotionContent, useMotionMount, useMotionRoot } from '@gentleduck/motion/use-motion-root'
 import type { SelectTriggerProps as PrimitiveSelectTriggerProps } from '@gentleduck/primitives/select'
 import * as SelectPrimitive from '@gentleduck/primitives/select'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { Check, ChevronDown, ChevronUp } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import * as React from 'react'
@@ -161,7 +162,7 @@ const MotionSelectContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
 >(({ className, children, position = 'popper', ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   const shouldRender = useMotionMount(isOpen)
 
   if (!shouldRender) return null

--- a/packages/registry-ui/src/sheet/sheet.tsx
+++ b/packages/registry-ui/src/sheet/sheet.tsx
@@ -8,6 +8,7 @@ import { tweenSlow } from '@gentleduck/motion/transitions/tweens'
 import { MotionRootContext, useMotionContent, useMotionMount, useMotionRoot } from '@gentleduck/motion/use-motion-root'
 import * as SheetPrimitive from '@gentleduck/primitives/sheet'
 import type { VariantProps } from '@gentleduck/variants'
+import { fadeIn } from '@gentleduck/motion/presets/fade-in'
 import { X } from 'lucide-react'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
@@ -123,7 +124,7 @@ const MotionSheetContent = React.forwardRef<
   SheetContentProps & { closeText?: string; hideClose?: boolean }
 >(({ side = 'right', className, children, closeText = 'Close', hideClose = false, ...props }, ref) => {
   const { isOpen } = useMotionContent()
-  const overlay = useMotionPreset('fadeIn')
+  const overlay = useMotionPreset(fadeIn)
   const slide = React.useMemo(() => createSlideEdge(side ?? 'right'), [side])
   // Sheet uses tweenSlow (300ms) for its slide, so give the exit a bit more
   // room before unmounting.

--- a/packages/registry-ui/src/skeleton/skeleton.tsx
+++ b/packages/registry-ui/src/skeleton/skeleton.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -32,7 +33,7 @@ const MotionSkeleton = React.forwardRef<
   }
 >(({ className, dir, index = 0, ...props }, ref) => {
   const direction = useDirection(dir as Direction)
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.05 })
   return (
     <LazyMotion features={loadDomAnimation}>
       <m.div

--- a/packages/registry-ui/src/slider/slider.tsx
+++ b/packages/registry-ui/src/slider/slider.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import * as SliderPrimitive from '@gentleduck/primitives/slider'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -70,7 +71,7 @@ const MotionSlider = React.forwardRef<
   React.ComponentRef<typeof SliderPrimitive.Root>,
   React.ComponentProps<typeof SliderPrimitive.Root>
 >(({ className, defaultValue, orientation = 'horizontal', value, min = 0, max = 100, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   const _values = React.useMemo(
     () => (Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min, max]),
     [value, defaultValue, min, max],

--- a/packages/registry-ui/src/table/table.tsx
+++ b/packages/registry-ui/src/table/table.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -107,7 +108,7 @@ const MotionTable = React.forwardRef<
   Omit<React.HTMLAttributes<HTMLTableElement>, 'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'>
 >(({ className, dir, ...props }, ref) => {
     const direction = useDirection(dir as Direction)
-    const content = useMotionPreset('scaleIn', { transition: springBouncy })
+    const content = useMotionPreset(scaleIn, { transition: springBouncy })
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.div
@@ -130,7 +131,7 @@ const MotionTableRow = React.forwardRef<
     index?: number
   }
 >(({ className, index = 0, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy, delay: index * 0.05 })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy, delay: index * 0.05 })
   return (
     <m.tr
       className={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', className)}

--- a/packages/registry-ui/src/textarea/textarea.tsx
+++ b/packages/registry-ui/src/textarea/textarea.tsx
@@ -5,6 +5,7 @@ import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import { type Direction, useDirection } from '@gentleduck/primitives/direction'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -29,7 +30,7 @@ Textarea.displayName = 'Textarea'
 
 const MotionTextarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
   (props, ref) => {
-    const content = useMotionPreset('scaleIn', { transition: springBouncy })
+    const content = useMotionPreset(scaleIn, { transition: springBouncy })
     return (
       <LazyMotion features={loadDomAnimation}>
         <m.div

--- a/packages/registry-ui/src/toggle/toggle.tsx
+++ b/packages/registry-ui/src/toggle/toggle.tsx
@@ -7,6 +7,7 @@ import { tapScale } from '@gentleduck/motion/presets/content'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
 import * as TogglePrimitive from '@gentleduck/primitives/toggle'
 import type { VariantProps } from '@gentleduck/variants'
+import { scaleIn } from '@gentleduck/motion/presets/scale-in'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 import { toggleVariants } from './toggle.constants'
@@ -33,7 +34,7 @@ const MotionToggle = React.forwardRef<
     'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart'
   >
 >(({ className, variant = 'default', size = 'default', children, ...props }, ref) => {
-  const content = useMotionPreset('scaleIn', { transition: springBouncy })
+  const content = useMotionPreset(scaleIn, { transition: springBouncy })
   return (
     <LazyMotion features={loadDomAnimation}>
       <TogglePrimitive.Root asChild ref={ref} {...props}>

--- a/packages/registry-ui/src/typography/typography.tsx
+++ b/packages/registry-ui/src/typography/typography.tsx
@@ -4,6 +4,7 @@ import { cn } from '@gentleduck/libs/cn'
 import { loadDomAnimation } from '@gentleduck/motion/motion-features'
 import { useMotionPreset } from '@gentleduck/motion/motion-presets'
 import { springBouncy } from '@gentleduck/motion/transitions/springs'
+import { slideUp } from '@gentleduck/motion/presets/slide-up'
 import { LazyMotion, m } from 'motion/react'
 import * as React from 'react'
 
@@ -158,7 +159,7 @@ TypographyTd.displayName = 'TypographyTd'
 type MotionIndexProps = { index?: number }
 
 function useTypographyMotion(index: number) {
-  return useMotionPreset('slideUp', {
+  return useMotionPreset(slideUp, {
     transition: springBouncy,
     delay: index * 0.05,
   })


### PR DESCRIPTION
useMotionPreset now accepts either a preset name string (backward compatible, bundles all presets) or a preset object directly (tree-shakeable, only the imported preset is bundled). All 41 registry-ui component files migrated from string lookups to direct imports. Presets actually used are scaleIn (57 calls), fadeIn (3), slideUp (1), slideFromLeft (1). Presets now tree-shakeable as dead code: fadeOut, slideDown, slideFromRight.