### PR TITLE
docs: sync duck-motion and duck-variants docs with refactored API

### DIFF
--- a/apps/duck-ui-docs/content/docs/packages/duck-motion.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-motion.mdx
@@ -24,123 +24,460 @@ npm install @gentleduck/motion
 
 ```tsx
 import '@gentleduck/motion/css'
-import { motionTransition, useDuckReducedMotion } from '@gentleduck/motion'
+import { MotionProvider, motionTransition, useDuckReducedMotion } from '@gentleduck/motion'
 ```
 
 ```tsx
-const reduced = useDuckReducedMotion()
-const transition = motionTransition(reduced, { duration: 240, easing: 'var(--gentleduck-motion-ease)' })
+function App() {
+  return (
+    <MotionProvider>
+      {/* All m.* components inside get consistent defaults */}
+    </MotionProvider>
+  )
+}
 ```
 
 ## Motion Library Integration
 
-`@gentleduck/motion` optionally integrates with the [motion](https://motion.dev) library (v12+) for richer animations with enter/exit transitions, layout animations, and gesture support. The motion library is an **optional peer dependency**  -  install it only when you need it.
+`@gentleduck/motion` integrates with the [motion](https://motion.dev) library (v12+) for richer animations with enter/exit transitions, layout animations, and gesture support. The motion library is an **optional peer dependency** — install it only when you need it.
 
 ```bash
 npm install motion
 ```
 
-### `motion-tokens`
+## API Reference
 
-Maps duck-ui duration and easing tokens to motion-compatible `Transition` objects:
+### `MotionProvider`
 
-```tsx
-import { duckMotionDuration, duckMotionEasing, duckMotionTransition } from '@gentleduck/motion/motion-tokens'
-
-// Duration in seconds (converted from ms)
-duckMotionDuration.fast    // 0.15
-duckMotionDuration.normal  // 0.2
-duckMotionDuration.slow    // 0.3
-
-// Easing as cubic-bezier arrays
-duckMotionEasing.standard  // [0.4, 0, 0.2, 1]
-duckMotionEasing.spring    // [1, 0.23995, 0, 1.65]
-
-// Ready-to-use transition objects
-<m.div transition={duckMotionTransition.fast} />
-```
-
-### `motion-features`
-
-LazyMotion feature loaders for optimal bundle size (~5KB instead of ~34KB):
+Wraps `LazyMotion` + `MotionConfig` with duck-ui defaults and reduced-motion support.
 
 ```tsx
-import { loadDomAnimation, loadDomMax, loadMotionFeatures } from '@gentleduck/motion/motion-features'
-import { LazyMotion, m } from 'motion/react'
+import { MotionProvider } from '@gentleduck/motion'
 
-// Default: animate, exit, variants, hover, tap, focus (~5KB)
-<LazyMotion features={loadDomAnimation}>
-  <m.div animate={{ opacity: 1 }} />
-</LazyMotion>
-
-// Full: adds layout animations, drag, viewport detection (~34KB)
-<LazyMotion features={loadDomMax}>
-  <m.div layout />
-</LazyMotion>
-```
-
-### `motion-provider`
-
-Wraps `LazyMotion` + `MotionConfig` with duck-ui defaults and reduced-motion support:
-
-```tsx
-import { MotionProvider } from '@gentleduck/motion/motion-provider'
-
-<MotionProvider>
-  {/* All m.* components inside get consistent defaults */}
-  <m.div animate={{ opacity: 1 }} />
-</MotionProvider>
+function App() {
+  return (
+    <MotionProvider exitTransition={{ duration: 0.32 }}>
+      <m.div animate={{ opacity: 1 }} />
+    </MotionProvider>
+  )
+}
 ```
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
-| `transition` | `object` | `duckMotionTransition.fast` | Global default transition |
-| `reducedMotion` | `'user' \| 'always' \| 'never'` | `'user'` | Reduced-motion strategy |
+| `children` | `React.ReactNode` | — | Content to render inside the provider |
+| `transition` | `Transition` | `{ duration: 0.15, ease: [0.4, 0, 0.2, 1] }` | Global default transition |
+| `enterTransition` | `Transition` | — | Override transition for enter animations only |
+| `exitTransition` | `Transition` | — | Override transition for exit animations only |
+| `reducedMotion` | `'user' \| 'always' \| 'never'` | `'user'` | Reduced-motion strategy passed to `MotionConfig` |
 | `features` | `() => Promise<FeatureBundle>` | `loadDomAnimation` | LazyMotion feature loader |
-| `strict` | `boolean` | `false` | Warn on `motion.*` usage (should use `m.*`) |
+| `strict` | `boolean` | `false` | Enable strict mode (warns on `motion.*` usage) |
 
-### `motion-presets`
+### `useMotionConfig`
 
-Pre-built animation configs ready to spread onto motion components:
+Access the `IMotionConfigContextValue` from inside a `MotionProvider`.
 
 ```tsx
-import { useMotionPreset } from '@gentleduck/motion/motion-presets'
+import { useMotionConfig } from '@gentleduck/motion'
 
-function FadeInCard() {
-  const fadeIn = useMotionPreset('fadeIn')
-  return <m.div {...fadeIn}>Hello</m.div>
+function MyComponent() {
+  const { exitTransition } = useMotionConfig()
+  // ...
 }
 ```
 
-Available presets: `fadeIn`, `fadeOut`, `scaleIn`, `slideUp`, `slideDown`, `slideFromLeft`, `slideFromRight`.
+Returns `IMotionConfigContextValue`:
 
-Each returns `{ initial, animate, exit, transition }`. When `prefers-reduced-motion` is active, `transition` becomes `{ duration: 0 }`.
+| Field | Type | Description |
+| --- | --- | --- |
+| `exitTransition` | `Transition \| undefined` | Exit transition set on the nearest `MotionProvider` |
 
-## API Reference
+### `IDuckMotion` namespace
 
-### CSS entrypoint
+Type namespace for all motion-related types. Import as a type only.
 
-`@gentleduck/motion/css` provides motion tokens and `prefers-reduced-motion` defaults:
+```tsx
+import type { IDuckMotion } from '@gentleduck/motion'
 
-- `--gentleduck-motion-ease`  -  cubic-bezier easing curve
-- `--gentleduck-motion-spring`  -  spring-like easing via `linear()` keyframe stops
-- `--gentleduck-motion-dur`  -  default duration (150ms)
+const preset: IDuckMotion.IPreset = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+}
+```
 
-### `react`
+Available types: `IAnimationState`, `ITransitionConfig`, `IPreset`, `IPresetResult`, `IPresetOptions`, `IPresetName`, `IDirection`.
 
-- `useDuckReducedMotion()`  -  returns `boolean` indicating reduced motion preference
-- `motionTransition(reduced, normal)`  -  returns a transition object respecting reduced motion
-- `onDuckReducedMotionChange(callback)`  -  subscribe to reduced motion preference changes
-- `getDuckReducedMotionServerSnapshot()`  -  SSR-safe snapshot for reduced motion state
+---
 
-### `anim`
+## Stagger Utilities
 
-- `AnimVariants`  -  CVA variant utility for animation classes
-- `checkersStylePattern`  -  CVA variant utility for checkbox/radio/switch patterns
+Helpers for staggered enter animations.
 
-### `tokens`
+```tsx
+import { getStaggerDelay, createStagger, staggerChildren } from '@gentleduck/motion'
+```
 
-- `duckEasing`  -  easing curve values (`standard`, `spring`)
-- `duckDuration`  -  duration values (`instant`, `fast`, `normal`, `slow`)
-- `duckMotionCssVar`  -  CSS variable references
+### `getStaggerDelay`
 
+Returns the stagger delay in seconds for a single item. Avoids allocating an array when only one delay is needed.
+
+```tsx
+const delay = getStaggerDelay(index, 50, 100) // (index * 50ms + 100ms) / 1000
+```
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `index` | `number` | — | Item index |
+| `staggerMs` | `number` | — | Per-item stagger in milliseconds |
+| `delayMs` | `number` | `0` | Initial delay before the first item in milliseconds |
+
+### `createStagger`
+
+Creates an array of `{ delay }` objects (in seconds) for staggered animations.
+
+```tsx
+const delays = createStagger(5, 50, 100)
+// [{ delay: 0.1 }, { delay: 0.15 }, { delay: 0.2 }, { delay: 0.25 }, { delay: 0.3 }]
+
+delays.map(({ delay }, i) => (
+  <m.div key={i} animate={{ opacity: 1 }} transition={{ delay }}>
+    Item {i}
+  </m.div>
+))
+```
+
+### `staggerChildren`
+
+Returns a `Transition` config for motion's `staggerChildren` / `delayChildren`. Spread into a parent variant's `transition` field.
+
+```tsx
+const containerVariants = {
+  animate: {
+    transition: staggerChildren(50, 100),
+  },
+}
+
+<m.ul variants={containerVariants} animate='animate'>
+  {items.map((item) => (
+    <m.li key={item.id} variants={itemVariants}>
+      {item.label}
+    </m.li>
+  ))}
+</m.ul>
+```
+
+---
+
+## Transitions
+
+### Duration tokens
+
+```tsx
+import { duckMotionDuration, duckMotionDurationMs } from '@gentleduck/motion'
+
+// Seconds (for motion library)
+duckMotionDuration.instant  // 0
+duckMotionDuration.fast    // 0.15
+duckMotionDuration.normal  // 0.2
+duckMotionDuration.slow    // 0.3
+
+// Milliseconds (for CSS)
+duckMotionDurationMs.instant  // 0
+duckMotionDurationMs.fast     // 150
+duckMotionDurationMs.normal   // 200
+duckMotionDurationMs.slow     // 300
+```
+
+### Easing tokens
+
+```tsx
+import { duckMotionEasing, duckMotionEasingCss } from '@gentleduck/motion'
+
+// Cubic-bezier arrays (for motion library)
+duckMotionEasing.standard  // [0.4, 0, 0.2, 1]
+duckMotionEasing.spring    // [1, 0.23995, 0, 1.65]
+
+// CSS strings (for CSS transitions)
+duckMotionEasingCss.standard  // 'cubic-bezier(0.4, 0, 0.2, 1)'
+duckMotionEasingCss.spring    // 'cubic-bezier(1, 0.23995, 0, 1.65)'
+```
+
+### Tween presets
+
+Ready-to-use tween `Transition` objects. Import individually:
+
+```tsx
+import {
+  tweenFast,
+  tweenNormal,
+  tweenSlow,
+  tweenMicro,
+  tweenInstant,
+  tweenExit,
+  tweenExpand,
+  tweenShake,
+} from '@gentleduck/motion'
+```
+
+| Name | Duration | Ease | Use case |
+| --- | --- | --- | --- |
+| `tweenInstant` | 0 | — | Immediate state changes |
+| `tweenMicro` | 100ms | ease-out | Tooltips, micro-interactions |
+| `tweenFast` | 150ms | standard | Hover states, toggles, tooltips |
+| `tweenNormal` | 200ms | standard | Overlays, content reveals |
+| `tweenSlow` | 300ms | standard | Large layout changes, page transitions |
+| `tweenExit` | 200ms | aggressive | Closing menus and dialogs |
+| `tweenExpand` | 250ms | expo-out | Accordion, collapsible, height reveals |
+| `tweenShake` | 400ms | — | Error shake feedback |
+
+### Spring presets
+
+Ready-to-use spring `Transition` objects:
+
+```tsx
+import {
+  springDefault,
+  springBouncy,
+  springGentle,
+  springSmooth,
+  springSnappy,
+  springStiff,
+  springInstant,
+} from '@gentleduck/motion'
+```
+
+| Name | Config | Use case |
+| --- | --- | --- |
+| `springDefault` | `visualDuration: 0.25, bounce: 0.2` | General-purpose spring |
+| `springSnappy` | `visualDuration: 0.2, bounce: 0.15` | Menus, dropdowns, popovers |
+| `springGentle` | `visualDuration: 0.35, bounce: 0.25` | Dialogs, sheets, drawers |
+| `springBouncy` | `stiffness: 500, damping: 28` | Menus and popovers with slight overshoot |
+| `springStiff` | `stiffness: 400, damping: 30` | Alert dialogs, destructive confirmations |
+| `springSmooth` | `stiffness: 350, damping: 30` | Layout indicators, sliding elements |
+| `springInstant` | `stiffness: 1000, damping: 100` | Reduced-motion fallback |
+
+---
+
+## Presets
+
+Pre-built animation configs ready to spread onto motion components.
+
+### Content presets
+
+```tsx
+import {
+  spinIn,
+  slideUpBlur,
+  fadeUp,
+  scaleBlur,
+  fadeBlur,
+  collapseX,
+  fadeBlurPopOut,
+  blurMount,
+  tapScale,
+  contentTransition,
+  contentTransitionFast,
+} from '@gentleduck/motion'
+```
+
+| Name | Use case |
+| --- | --- |
+| `spinIn` | Icon swaps, loading spinners, status indicators |
+| `slideUpBlur` | Text reveals, labels, descriptions |
+| `fadeUp` | Content mount, tags, chips, toggle children |
+| `scaleBlur` | Images, media, aspect-ratio containers |
+| `fadeBlur` | Buttons, containers, overlays |
+| `collapseX` | Text/icon collapse inside buttons |
+| `fadeBlurPopOut` | Collapsible button children with `popLayout` |
+| `blurMount` | CSS-driven opacity (e.g. disabled states) |
+| `tapScale` | Use as `whileTap={tapScale}` on buttons and toggles |
+| `contentTransition` | 250ms expo-out for smooth reveals |
+| `contentTransitionFast` | 150ms expo-out for button content swaps |
+
+### Basic presets
+
+```tsx
+import {
+  fadeIn,
+  fadeOut,
+  popIn,
+  rotateIn,
+  scaleIn,
+  slideUp,
+  slideDown,
+  slideFromLeft,
+  slideFromRight,
+} from '@gentleduck/motion'
+```
+
+All basic presets return `{ initial, animate, exit }` objects. Spread them directly onto motion components:
+
+```tsx
+<m.div {...fadeIn} transition={tweenFast}>
+  Content
+</m.div>
+```
+
+### `heightAuto`
+
+Height expand/collapse preset for accordion and collapsible content. Stays mounted and toggles between `open` and `closed` states.
+
+```tsx
+import { heightAuto } from '@gentleduck/motion'
+
+<m.div animate={isOpen ? heightAuto.open : heightAuto.closed} transition={tweenExpand}>
+  Collapsible content
+</m.div>
+```
+
+### `createDirectionalPreset`
+
+Factory for directional enter/exit animations with scale and blur.
+
+```tsx
+import { createDirectionalPreset } from '@gentleduck/motion'
+
+const fromBottom = createDirectionalPreset('bottom')
+const fromTop = createDirectionalPreset('top', 12, 40, 12)
+
+<m.div {...fromBottom} transition={springSnappy}>
+  Drawer content
+</m.div>
+```
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `direction` | `'top' \| 'bottom' \| 'left' \| 'right'` | — | Enter direction |
+| `enterOffset` | `number` | `8` | Offset in px for enter animation |
+| `exitOffset` | `number` | `30` | Offset in px for exit animation |
+| `blur` | `number` | `8` | Blur amount in px |
+
+---
+
+## Variants
+
+CVA-based variant utilities for applying animation classes.
+
+### `AnimVariants`
+
+CVA variant for applying transition properties to animated elements.
+
+```tsx
+import { AnimVariants } from '@gentleduck/motion'
+
+<div className={AnimVariants({ alive: 'default', pseudo: 'animate' })}>
+  Animated content
+</div>
+```
+
+| Variant | Values | Description |
+| --- | --- | --- |
+| `alive` | `'default'` | Applies `transition-all`, `duration`, and `ease` classes |
+| `pseudo` | `'animate' \| 'default'` | Applies GPU-accelerated pseudo-element transitions |
+
+### `checkersStylePattern`
+
+CVA variant for checkbox, radio, and switch patterns.
+
+```tsx
+import { checkersStylePattern } from '@gentleduck/motion'
+
+<input
+  type='checkbox'
+  className={checkersStylePattern({ type: 'checkbox', indicatorState: 'both' })}
+/>
+```
+
+| Variant | Values | Description |
+| --- | --- | --- |
+| `type` | `'checkbox' \| 'radio' \| 'switch'` | Control type — drives shape, padding, and animation direction |
+| `indicatorState` | `'default' \| 'both' \| 'indicatorReady' \| 'checkedIndicatorReady'` | Mask image strategy for the indicator SVG |
+
+---
+
+## Reduced-motion API
+
+### `useDuckReducedMotion`
+
+Returns `true` if the user prefers reduced motion. Uses `useSyncExternalStore` for efficient media query subscription.
+
+```tsx
+import { useDuckReducedMotion } from '@gentleduck/motion'
+
+function MyComponent() {
+  const reduced = useDuckReducedMotion()
+  return <m.div transition={reduced ? { duration: 0 } : tweenNormal} />
+}
+```
+
+### `motionTransition`
+
+Returns the `normal` transition, or `{ duration: 0 }` when `reduced` is `true`.
+
+```tsx
+import { motionTransition, useDuckReducedMotion } from '@gentleduck/motion'
+
+const reduced = useDuckReducedMotion()
+const transition = motionTransition(reduced, tweenNormal)
+```
+
+### `onDuckReducedMotionChange`
+
+Subscribe to changes in the reduced-motion preference. Returns an unsubscribe function.
+
+```tsx
+import { onDuckReducedMotionChange } from '@gentleduck/motion'
+
+const unsubscribe = onDuckReducedMotionChange(() => {
+  console.log('reduced motion preference changed')
+})
+```
+
+### `getDuckReducedMotionServerSnapshot`
+
+SSR-safe snapshot — always returns `false` on the server.
+
+```tsx
+import { getDuckReducedMotionServerSnapshot } from '@gentleduck/motion'
+
+const reduced = getDuckReducedMotionServerSnapshot() // false
+```
+
+### `IReducedMotionFallback`
+
+Type for the reduced-motion fallback object `{ duration: 0 }`.
+
+```tsx
+import type { IReducedMotionFallback } from '@gentleduck/motion'
+```
+
+---
+
+## Backward-compat tokens
+
+These tokens are still exported but prefer the newer names.
+
+```tsx
+import { duckDuration, duckEasing, duckMotionCssVar } from '@gentleduck/motion'
+```
+
+| Export | Maps to | Description |
+| --- | --- | --- |
+| `duckDuration` | `duckMotionDurationMs` | Duration values in milliseconds |
+| `duckEasing` | `duckMotionEasingCss` | Easing as CSS `cubic-bezier()` strings |
+| `duckMotionCssVar` | — | CSS variable references with fallbacks |
+
+---
+
+## CSS entrypoint
+
+```tsx
+import '@gentleduck/motion/css'
+```
+
+Provides motion tokens and `prefers-reduced-motion` defaults:
+
+- `--gentleduck-motion-ease` — cubic-bezier easing curve
+- `--gentleduck-motion-spring` — spring-like easing via `linear()` keyframe stops
+- `--gentleduck-motion-dur` — default duration (150ms)

--- a/apps/duck-ui-docs/content/docs/packages/duck-variants.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-variants.mdx
@@ -79,8 +79,8 @@ const fn = cva(baseOrOptions, maybeOptions?)
 fn(props?) // returns string
 ```
 
-**Important types:** `VariantProps<typeof fn>`, `CvaProps<TVariants>`,
-`ClassValue`.
+**Important types:** `Variants.VariantProps<typeof fn>`, `Variants.Props<TVariants>`,
+`Variants.ClassValue`.
 
 For complete signatures and the TypeScript definitions, see the Types
 Reference section at the bottom.
@@ -92,7 +92,7 @@ Reference section at the bottom.
 ### 1) Button component (production-ready)
 
 ```tsx
-import { cva, type VariantProps } from '@gentleduck/variants'
+import { cva, type Variants } from '@gentleduck/variants'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva('inline-flex items-center justify-center rounded', {
@@ -106,7 +106,7 @@ const buttonVariants = cva('inline-flex items-center justify-center rounded', {
   defaultVariants: { variant: 'default', size: 'md' }
 })
 
-type ButtonProps = VariantProps<typeof buttonVariants> & React.ButtonHTMLAttributes<HTMLButtonElement>
+type ButtonProps = Variants.VariantProps<typeof buttonVariants> & React.ButtonHTMLAttributes<HTMLButtonElement>
 
 export function Button({ className, variant, size, ...props }: ButtonProps) {
   return <button className={cn(buttonVariants({ variant, size }), className)} {...props} />
@@ -229,24 +229,24 @@ A: Pass the literal string `'unset'` for that variant: e.g.
 
 ## Types reference
 
-### 1. Variant Params
+All types are exported under the `Variants` namespace from `@gentleduck/variants`.
 
-This defines the mapping of **variant names** (like `size`, `intent`, etc.) to their **possible values**.
-It accepts either a single key or an array of keys for each variant.
+### 1. Variant Params (`Variants.VariantParams`)
+
+Maps each variant key to a selected value or array of values.
+Accepts either a single key or a `ReadonlyArray` of keys for each variant, or `null` to clear a default.
 
 
-```tsx title="variants.ts"
-export type VariantParams<
-  TVariants extends Record<string, Record<string, string | string[]>>
-> = {
-  [K in keyof TVariants]?: keyof TVariants[K] | Array<keyof TVariants[K]>
+```tsx title="variants.types.ts"
+export type VariantParams<TVariants extends VariantDefinitions> = {
+  readonly [K in keyof TVariants]?: keyof TVariants[K] | ReadonlyArray<keyof TVariants[K]> | null
 }
 ```
 
 
-### 2. CVA Configuration
+### 2. CVA Options (`Variants.Options`)
 
-Defines how to configure a **CVA function**, including:
+Options for creating a CVA function, without the `base` classes.
 
 | Field | Description |
 | --- | --- |
@@ -255,74 +255,86 @@ Defines how to configure a **CVA function**, including:
 | `compoundVariants` | Conditional styles that apply when multiple variants match. |
 
 
-```tsx title="variants.ts"
-export interface VariantsOptions<
-  TVariants extends Record<string, Record<string, string | string[]>>
-> {
-  variants: TVariants
-  defaultVariants?: VariantParams<TVariants>
-  compoundVariants?: Array<
+```tsx title="variants.types.ts"
+export type Options<TVariants extends VariantDefinitions> = {
+  readonly variants?: TVariants
+  readonly defaultVariants?: VariantParams<TVariants>
+  readonly compoundVariants?: ReadonlyArray<
     VariantParams<TVariants> & {
-      class?: ClassValue
-      className?: ClassValue
+      readonly class?: ClassValue
+      readonly className?: ClassValue
     }
   >
 }
 ```
 
 
-### 3. CVA Props
+### 3. CVA Config (`Variants.Config`)
+
+Full configuration accepted by `cva()`: `Options` plus optional `base` classes.
+
+
+```tsx title="variants.types.ts"
+export type Config<TVariants extends VariantDefinitions> = Options<TVariants> & {
+  readonly base?: ClassValue
+}
+```
+
+
+### 4. CVA Props (`Variants.Props`)
 
 Props that a **CVA-generated function** accepts.
 Includes both **variant selections** and optional `class`/`className` overrides.
 
 
-```tsx title="variants.ts"
-export type CvaProps<
-  TVariants extends Record<string, Record<string, string | string[]>>
-> = VariantParams<TVariants> & {
-  className?: ClassValue
-  class?: ClassValue
+```tsx title="variants.types.ts"
+export type Props<TVariants extends VariantDefinitions> = VariantParams<TVariants> & {
+  readonly className?: ClassValue
+  readonly class?: ClassValue
 }
 ```
 
 
-### 4. Variant Props
+### 5. Variant Props (`Variants.VariantProps`)
 
 Utility type to **extract only the variant-related props** from a CVA function, omitting `class` and `className`.
 
 
-```tsx title="variants.ts"
-type RemoveArray<T> = T extends unknown[] ? never : T
-
+```tsx title="variants.types.ts"
 export type VariantProps<T> = T extends (props?: infer P) => string
-  ? {
-      [K in keyof P as K extends 'class' | 'className' ? never : K]: RemoveArray<P[K]>
-    }
+  ? Omit<NonNullable<P>, 'class' | 'className'>
   : never
 ```
 
 
-### 5. Class Utility Types
+### 6. Infer (`Variants.Infer`)
+
+Infers the `variants` field from an `Options` object. Useful when you want to extract the variant map from a config constant.
+
+
+```tsx title="variants.types.ts"
+export type Infer<T extends Options<VariantDefinitions>> = T['variants']
+```
+
+
+### 7. Class Utility Types
 
 Helper types that define the **shape of class names**:
 
 | Type | Purpose |
 | --- | --- |
-| `ClassDictionary` | Conditional `{ 'class': boolean }`. |
-| `ClassArray` | Nested arrays of class values. |
-| `ClassValue` | Union of everything accepted as a class. |
+| `Variants.ClassDictionary` | Conditional `{ 'class': boolean \| null \| undefined }`. Readonly. |
+| `Variants.ClassArray` | Readonly nested arrays of class values. |
+| `Variants.ClassValue` | Union of everything accepted as a class. |
+| `Variants.ClassPrimitive` | Primitive scalar values (string, number, bigint, boolean, null, undefined). |
 
 
-```tsx title="variants.ts"
-export type ClassDictionary = Record<string, boolean | undefined>
+```tsx title="variants.types.ts"
+export type ClassPrimitive = string | number | bigint | boolean | null | undefined
 
-export type ClassArray = ClassValue[]
+export type ClassDictionary = Readonly<Record<string, boolean | null | undefined>>
 
-export type ClassValue =
-  | string
-  | number
-  | boolean
-  | ClassDictionary
-  | ClassArray
+export type ClassArray = ReadonlyArray<ClassValue>
+
+export type ClassValue = ClassPrimitive | ClassDictionary | ClassArray
 ```

--- a/packages/duck-cli/src/commands/add/add.ts
+++ b/packages/duck-cli/src/commands/add/add.ts
@@ -4,10 +4,10 @@ import { addCommandConfig } from './add.constants'
 import { addCommandAction } from './add.libs'
 
 const { name, description, options, arguments_ } = addCommandConfig
-const option1 = requireConfigValue(options['option1'], 'missing add command option1 config')
-const option2 = requireConfigValue(options['option2'], 'missing add command option2 config')
-const option3 = requireConfigValue(options['option3'], 'missing add command option3 config')
-const arg1 = requireConfigValue(arguments_['arg1'], 'missing add command arg1 config')
+const option1 = requireConfigValue(options.option1, 'missing add command option1 config')
+const option2 = requireConfigValue(options.option2, 'missing add command option2 config')
+const option3 = requireConfigValue(options.option3, 'missing add command option3 config')
+const arg1 = requireConfigValue(arguments_.arg1, 'missing add command arg1 config')
 
 export function addCommand(): Command {
   const addCommand = new Command(name)

--- a/packages/duck-cli/src/commands/diff/diff.ts
+++ b/packages/duck-cli/src/commands/diff/diff.ts
@@ -4,9 +4,9 @@ import { diffCommandConfig } from './diff.constants'
 import { diffCommandAction } from './diff.libs'
 
 const { name, description, options, arguments_ } = diffCommandConfig
-const option1 = requireConfigValue(options['option1'], 'missing diff command option1 config')
-const option2 = requireConfigValue(options['option2'], 'missing diff command option2 config')
-const arg1 = requireConfigValue(arguments_['arg1'], 'missing diff command arg1 config')
+const option1 = requireConfigValue(options.option1, 'missing diff command option1 config')
+const option2 = requireConfigValue(options.option2, 'missing diff command option2 config')
+const arg1 = requireConfigValue(arguments_.arg1, 'missing diff command arg1 config')
 
 export function diffCommand(): Command {
   const cmd = new Command(name)

--- a/packages/duck-cli/src/commands/init/init.ts
+++ b/packages/duck-cli/src/commands/init/init.ts
@@ -4,9 +4,9 @@ import { initCommandConfig } from './init.constants'
 import { initCommandAction } from './init.libs'
 
 const { name, description, options, arguments_ } = initCommandConfig
-const option1 = requireConfigValue(options['option1'], 'missing init command option1 config')
-const option2 = requireConfigValue(options['option2'], 'missing init command option2 config')
-const arg1 = requireConfigValue(arguments_['arg1'], 'missing init command arg1 config')
+const option1 = requireConfigValue(options.option1, 'missing init command option1 config')
+const option2 = requireConfigValue(options.option2, 'missing init command option2 config')
+const arg1 = requireConfigValue(arguments_.arg1, 'missing init command arg1 config')
 
 export function initCommand(): Command {
   const initCommand = new Command(name)

--- a/packages/duck-cli/src/commands/list/list.ts
+++ b/packages/duck-cli/src/commands/list/list.ts
@@ -4,8 +4,8 @@ import { listCommandConfig } from './list.constants'
 import { listCommandAction } from './list.libs'
 
 const { name, description, options } = listCommandConfig
-const option1 = requireConfigValue(options['option1'], 'missing list command option1 config')
-const option2 = requireConfigValue(options['option2'], 'missing list command option2 config')
+const option1 = requireConfigValue(options.option1, 'missing list command option1 config')
+const option2 = requireConfigValue(options.option2, 'missing list command option2 config')
 
 export function listCommand(): Command {
   const cmd = new Command(name)

--- a/packages/duck-cli/src/commands/remove/remove.ts
+++ b/packages/duck-cli/src/commands/remove/remove.ts
@@ -4,9 +4,9 @@ import { removeCommandConfig } from './remove.constants'
 import { removeCommandAction } from './remove.libs'
 
 const { name, description, options, arguments_ } = removeCommandConfig
-const option1 = requireConfigValue(options['option1'], 'missing remove command option1 config')
-const option2 = requireConfigValue(options['option2'], 'missing remove command option2 config')
-const arg1 = requireConfigValue(arguments_['arg1'], 'missing remove command arg1 config')
+const option1 = requireConfigValue(options.option1, 'missing remove command option1 config')
+const option2 = requireConfigValue(options.option2, 'missing remove command option2 config')
+const arg1 = requireConfigValue(arguments_.arg1, 'missing remove command arg1 config')
 
 export function removeCommand(): Command {
   const cmd = new Command(name)

--- a/packages/duck-cli/src/commands/update/update.ts
+++ b/packages/duck-cli/src/commands/update/update.ts
@@ -4,10 +4,10 @@ import { updateCommandConfig } from './update.constants'
 import { updateCommandAction } from './update.libs'
 
 const { name, description, options, arguments_ } = updateCommandConfig
-const option1 = requireConfigValue(options['option1'], 'missing update command option1 config')
-const option2 = requireConfigValue(options['option2'], 'missing update command option2 config')
-const option3 = requireConfigValue(options['option3'], 'missing update command option3 config')
-const arg1 = requireConfigValue(arguments_['arg1'], 'missing update command arg1 config')
+const option1 = requireConfigValue(options.option1, 'missing update command option1 config')
+const option2 = requireConfigValue(options.option2, 'missing update command option2 config')
+const option3 = requireConfigValue(options.option3, 'missing update command option3 config')
+const arg1 = requireConfigValue(arguments_.arg1, 'missing update command arg1 config')
 
 export function updateCommand(): Command {
   const cmd = new Command(name)

--- a/packages/duck-cli/src/main/main.constants.ts
+++ b/packages/duck-cli/src/main/main.constants.ts
@@ -4,4 +4,4 @@ export const config = {
   version: '1.0.11',
 }
 
-export const REGISTRY_URL = process.env['COMPONENTS_REGISTRY_URL'] ?? 'https://ui.gentleduck.org/r'
+export const REGISTRY_URL = process.env.COMPONENTS_REGISTRY_URL ?? 'https://ui.gentleduck.org/r'

--- a/packages/duck-cli/src/main/main.ts
+++ b/packages/duck-cli/src/main/main.ts
@@ -19,7 +19,7 @@ export async function init() {
   duckUi.option('--verbose', 'show detailed error output for debugging', false)
   duckUi.hook('preAction', (thisCommand) => {
     const opts = thisCommand.opts()
-    if (opts['verbose']) {
+    if (opts.verbose) {
       setVerbose(true)
     }
   })

--- a/packages/duck-docs/src/components/layouts/ai-chat-panel.tsx
+++ b/packages/duck-docs/src/components/layouts/ai-chat-panel.tsx
@@ -204,7 +204,7 @@ const ShikiCodeBlock = React.memo(function ShikiCodeBlock({ code, language }: { 
             transformers: [
               {
                 pre(node) {
-                  node.properties['class'] =
+                  node.properties.class =
                     'no-scrollbar min-w-0 overflow-x-auto px-4 py-3.5 !bg-transparent text-[13px] leading-relaxed'
                 },
               },

--- a/packages/duck-docs/src/components/layouts/command-menu.tsx
+++ b/packages/duck-docs/src/components/layouts/command-menu.tsx
@@ -126,7 +126,7 @@ export function CommandMenu() {
   const [initialAiQuery, setInitialAiQuery] = React.useState('')
 
   // Build-time check  -  no runtime API call
-  const aiAvailable = process.env['NEXT_PUBLIC_AI_CHAT_ENABLED'] === 'true'
+  const aiAvailable = process.env.NEXT_PUBLIC_AI_CHAT_ENABLED === 'true'
 
   // Reset AI mode when dialog closes
   React.useEffect(() => {

--- a/packages/duck-docs/src/components/layouts/tailwind-indicator.tsx
+++ b/packages/duck-docs/src/components/layouts/tailwind-indicator.tsx
@@ -1,5 +1,5 @@
 export function TailwindIndicator() {
-  if (process.env['NODE_ENV'] === 'production') return null
+  if (process.env.NODE_ENV === 'production') return null
 
   return (
     <div

--- a/packages/duck-docs/src/components/mdx/mdx-components/code/code-preview.tsx
+++ b/packages/duck-docs/src/components/mdx/mdx-components/code/code-preview.tsx
@@ -52,17 +52,17 @@ function getElementProps(element: HTMLElement) {
     }
 
     if (attribute === 'class') {
-      props['className'] = value
+      props.className = value
       continue
     }
 
     if (attribute === 'style') {
-      props['style'] = parseInlineStyle(value)
+      props.style = parseInlineStyle(value)
       continue
     }
 
     if (attribute === 'tabindex') {
-      props['tabIndex'] = Number(value)
+      props.tabIndex = Number(value)
       continue
     }
 

--- a/packages/duck-docs/src/lib/utils.ts
+++ b/packages/duck-docs/src/lib/utils.ts
@@ -8,7 +8,7 @@ export function formatDate(input: string | number): string {
 }
 
 export function absoluteUrl(path: string) {
-  const baseUrl = process.env['NEXT_PUBLIC_APP_URL'] || ''
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || ''
   if (!baseUrl) return path
 
   const normalizedBase = baseUrl.replace(/\/+$/, '')

--- a/packages/duck-docs/src/velite/plugins/rehype-mermaid.ts
+++ b/packages/duck-docs/src/velite/plugins/rehype-mermaid.ts
@@ -79,7 +79,7 @@ function makeJsxStringAttr(name: string, value: string) {
 /** Find the system Chromium / Chrome binary. */
 function findChromium(): string {
   // 1) Honor explicit env var
-  const envPath = process.env['PUPPETEER_EXECUTABLE_PATH'] || process.env['CHROME_BIN'] || process.env['CHROMIUM_BIN']
+  const envPath = process.env.PUPPETEER_EXECUTABLE_PATH || process.env.CHROME_BIN || process.env.CHROMIUM_BIN
   if (envPath && existsSync(envPath)) return envPath
 
   // 2) Try PATH lookups

--- a/packages/duck-extension/src/App.tsx
+++ b/packages/duck-extension/src/App.tsx
@@ -143,8 +143,8 @@ function FontProvider({ children }: { children: React.ReactNode }) {
         chrome.storage.sync.get(
           ['gentleduck_domainFonts', 'gentleduck_disabledDomains'],
           (data: Record<string, unknown>) => {
-            const fonts = (data['gentleduck_domainFonts'] || {}) as Record<string, Font>
-            const disabled = (data['gentleduck_disabledDomains'] || []) as string[]
+            const fonts = (data.gentleduck_domainFonts || {}) as Record<string, Font>
+            const disabled = (data.gentleduck_disabledDomains || []) as string[]
 
             // Update cache
             storageCache = {

--- a/packages/duck-primitives/src/alert-dialog/content.tsx
+++ b/packages/duck-primitives/src/alert-dialog/content.tsx
@@ -43,7 +43,7 @@ export const AlertDialogContent = React.forwardRef<AlertDialogContentElement, IA
             onPointerDownOutside={(event) => event.preventDefault()}
             onInteractOutside={(event) => event.preventDefault()}>
             <Slottable>{children}</Slottable>
-            {process.env['NODE_ENV'] === 'development' && <DescriptionWarning contentRef={contentRef} />}
+            {process.env.NODE_ENV === 'development' && <DescriptionWarning contentRef={contentRef} />}
           </DialogPrimitive.Content>
         </AlertDialogContentProvider>
       </DialogPrimitive.WarningProvider>

--- a/packages/duck-primitives/src/dialog/content.tsx
+++ b/packages/duck-primitives/src/dialog/content.tsx
@@ -150,7 +150,7 @@ const DialogContentImpl = React.forwardRef<DialogContentImplElement, IDialog.ICo
             onDismiss={() => context.onOpenChange(false)}
           />
         </FocusScope>
-        {process.env['NODE_ENV'] !== 'production' && (
+        {process.env.NODE_ENV !== 'production' && (
           <>
             <TitleWarning titleId={context.titleId} />
             <DescriptionWarning contentRef={contentRef} descriptionId={context.descriptionId} />

--- a/packages/duck-primitives/src/hooks/use-controllable-state.tsx
+++ b/packages/duck-primitives/src/hooks/use-controllable-state.tsx
@@ -38,7 +38,7 @@ export function useControllableState<T>({
   // Hooks are called conditionally here but always in the same environment,
   // so bundlers can strip this block entirely in production.
   /* eslint-disable react-hooks/rules-of-hooks */
-  if (process.env['NODE_ENV'] !== 'production') {
+  if (process.env.NODE_ENV !== 'production') {
     // biome-ignore lint/correctness/useHookAtTopLevel: hooks are intentionally called inside a NODE_ENV check  -  the condition is static per build so hook order is stable at runtime
     const isControlledRef = React.useRef(prop !== undefined)
     // biome-ignore lint/correctness/useHookAtTopLevel: hooks are intentionally called inside a NODE_ENV check  -  the condition is static per build so hook order is stable at runtime

--- a/packages/duck-primitives/src/menu/sub-trigger.tsx
+++ b/packages/duck-primitives/src/menu/sub-trigger.tsx
@@ -75,7 +75,7 @@ const MenuSubTrigger = React.forwardRef<MenuSubTriggerElement, IMenu.ISubTrigger
 
               const contentRect = context.content?.getBoundingClientRect()
               if (contentRect) {
-                const side = context.content?.dataset['side'] as Side
+                const side = context.content?.dataset.side as Side
                 const rightSide = side === 'right'
                 const bleed = rightSide ? -5 : +5
                 const contentNearEdge = contentRect[rightSide ? 'left' : 'right']

--- a/packages/duck-primitives/src/navigation-menu/navigation-menu.libs.tsx
+++ b/packages/duck-primitives/src/navigation-menu/navigation-menu.libs.tsx
@@ -73,12 +73,12 @@ function focusFirst(candidates: HTMLElement[]) {
 
 function removeFromTabOrder(candidates: HTMLElement[]) {
   candidates.forEach((candidate) => {
-    candidate.dataset['tabindex'] = candidate.getAttribute('tabindex') || ''
+    candidate.dataset.tabindex = candidate.getAttribute('tabindex') || ''
     candidate.setAttribute('tabindex', '-1')
   })
   return () => {
     candidates.forEach((candidate) => {
-      const prevTabIndex = candidate.dataset['tabindex'] as string
+      const prevTabIndex = candidate.dataset.tabindex as string
       candidate.setAttribute('tabindex', prevTabIndex)
     })
   }

--- a/packages/duck-primitives/src/popper/content.tsx
+++ b/packages/duck-primitives/src/popper/content.tsx
@@ -133,8 +133,8 @@ export const PopperContent = ({ ref: forwardedRef, ...props }: IPopper.IScoped<I
           minWidth: 'max-content',
           zIndex: contentZIndex,
           '--gentleduck-popper-transform-origin': [
-            middlewareData['transformOrigin']?.x,
-            middlewareData['transformOrigin']?.y,
+            middlewareData.transformOrigin?.x,
+            middlewareData.transformOrigin?.y,
           ].join(' '),
           ...(middlewareData.hide?.referenceHidden && {
             visibility: 'hidden',

--- a/packages/duck-primitives/src/radio-group/radio-group.tsx
+++ b/packages/duck-primitives/src/radio-group/radio-group.tsx
@@ -46,7 +46,7 @@ const RadioGroup = React.forwardRef<RadioGroupElement, IRadioGroup.IProps>(
       ...groupProps
     } = props
     const rovingFocusGroupScope = useRovingFocusGroupScope(__scopeRadioGroup)
-    const getItems = RovingFocusGroup.useCollection(rovingFocusGroupScope['__scopeRovingFocusGroup'])
+    const getItems = RovingFocusGroup.useCollection(rovingFocusGroupScope.__scopeRovingFocusGroup)
     const direction = useDirection(dir)
     const isNavigationKeyPressedRef = React.useRef(false)
     const navigationResetTimerRef = React.useRef<number | null>(null)

--- a/packages/duck-primitives/src/slot/slot.tsx
+++ b/packages/duck-primitives/src/slot/slot.tsx
@@ -49,7 +49,7 @@ const Slot = createSlot('Slot')
       const childrenRef = getComponentRef(children)
       const props = mergeProps(slotProps, children.props as AnyProps)
       if (children.type !== React.Fragment) {
-        props['ref'] = forwardedRef ? composeRefs(forwardedRef, childrenRef) : childrenRef
+        props.ref = forwardedRef ? composeRefs(forwardedRef, childrenRef) : childrenRef
       }
       return React.cloneElement(children, props)
     }

--- a/packages/duck-variants/src/variants.ts
+++ b/packages/duck-variants/src/variants.ts
@@ -186,8 +186,8 @@ export function cva<TVariants extends Variants.VariantDefinitions>(
 
   return (props: Variants.Props<TVariants> = {} as Variants.Props<TVariants>): string => {
     const rawProps = props as Record<string, unknown>
-    const dynamicClassName = rawProps['className']
-    const dynamicClass = rawProps['class']
+    const dynamicClassName = rawProps.className
+    const dynamicClass = rawProps.class
     const hasDynamic = dynamicClassName != null || dynamicClass != null
 
     let cacheKey = ''

--- a/packages/registry-build/examples/arch-package-index/arch-repository.extension.ts
+++ b/packages/registry-build/examples/arch-package-index/arch-repository.extension.ts
@@ -49,8 +49,8 @@ export function archRepositoryExtension(options: ArchRepositoryExtensionOptions)
       const packages = toPackageArray(collection.data).slice().sort(byName)
       const outputRoot = path.join(api.paths.baseDir, options.outputDir ?? 'arch')
       const repoDir = path.join(outputRoot, 'repos')
-      const repoOrder = Array.isArray(collection.metadata['repoOrder'])
-        ? (collection.metadata['repoOrder'] as string[])
+      const repoOrder = Array.isArray(collection.metadata.repoOrder)
+        ? (collection.metadata.repoOrder as string[])
         : [...new Set(packages.map((pkg) => pkg.repo))].sort((left, right) => left.localeCompare(right))
       const search = packages.map((pkg) => ({
         arch: pkg.arch,

--- a/packages/registry-build/src/config/loader/loader.value.ts
+++ b/packages/registry-build/src/config/loader/loader.value.ts
@@ -15,7 +15,7 @@ export async function loadValueFile(filePath: string): Promise<unknown> {
     const moduleUrl = `${pathToFileURL(filePath).href}?t=${Date.now()}`
     const module = (await import(moduleUrl)) as Record<string, unknown>
 
-    return module['default'] ?? module
+    return module.default ?? module
   } catch (nativeError) {
     if (canUseJiti) {
       try {

--- a/packages/registry-examples/src/chart/chart-benchmark-calendar-compare.tsx
+++ b/packages/registry-examples/src/chart/chart-benchmark-calendar-compare.tsx
@@ -6,7 +6,7 @@ import data from '../../../../apps/duck-ui-docs/public/data/benchmarks/calendar.
 const tabs = ['vs react-day-picker', 'vs react-aria', 'vs react-datepicker', 'vs react-calendar'] as const
 type Tab = (typeof tabs)[number]
 
-const comparisons = (data as Record<string, unknown>)['libraryComparisons'] as
+const comparisons = (data as Record<string, unknown>).libraryComparisons as
   | {
       name: string
       comparison: { metric: string; gentleduck: string; competitor: string; winner: string }[]

--- a/packages/registry-examples/src/chart/chart-benchmark-calendar-vs.tsx
+++ b/packages/registry-examples/src/chart/chart-benchmark-calendar-vs.tsx
@@ -25,9 +25,7 @@ const totalCostConfig = {
   css: { label: 'CSS (KB)', color: 'var(--chart-2)' },
 } satisfies ChartConfig
 
-const totalCost = (data as Record<string, unknown>)['totalCost'] as
-  | { name: string; js: number; css: number }[]
-  | undefined
+const totalCost = (data as Record<string, unknown>).totalCost as { name: string; js: number; css: number }[] | undefined
 
 export default function CalendarBenchmarkVs() {
   const [tab, setTab] = React.useState<Tab>('Bundle Size')

--- a/packages/registry-examples/src/chart/chart-benchmark-calendar.tsx
+++ b/packages/registry-examples/src/chart/chart-benchmark-calendar.tsx
@@ -31,7 +31,7 @@ const adapterConfig = {
   format: { label: 'format (μs)', color: 'var(--chart-3)' },
 } satisfies ChartConfig
 
-const modules = (data as Record<string, unknown>)['moduleSizes'] as { name: string; sizeKB: number }[] | undefined
+const modules = (data as Record<string, unknown>).moduleSizes as { name: string; sizeKB: number }[] | undefined
 const pieData = modules
   ? modules.map((m, i) => ({ name: m.name, size: m.sizeKB, fill: COLORS[i % COLORS.length] }))
   : []

--- a/packages/registry-internals/src/internal-primitives/alert-dialog-confirm/alert-dialog-confirm.tsx
+++ b/packages/registry-internals/src/internal-primitives/alert-dialog-confirm/alert-dialog-confirm.tsx
@@ -5,20 +5,20 @@ import styles from './styles.module.css'
 
 export default function AlertDialogConfirmInternalExample() {
   return (
-    <div className={styles['frame']}>
-      <p className={styles['label']}>Destructive confirmation</p>
+    <div className={styles.frame}>
+      <p className={styles.label}>Destructive confirmation</p>
       <AlertDialog.AlertDialog>
-        <AlertDialog.AlertDialogTrigger className={styles['trigger']}>Open confirm</AlertDialog.AlertDialogTrigger>
+        <AlertDialog.AlertDialogTrigger className={styles.trigger}>Open confirm</AlertDialog.AlertDialogTrigger>
         <AlertDialog.AlertDialogPortal>
-          <AlertDialog.AlertDialogOverlay className={styles['overlay']} />
-          <AlertDialog.AlertDialogContent className={styles['content']}>
-            <AlertDialog.AlertDialogTitle className={styles['title']}>Delete resource?</AlertDialog.AlertDialogTitle>
-            <AlertDialog.AlertDialogDescription className={styles['description']}>
+          <AlertDialog.AlertDialogOverlay className={styles.overlay} />
+          <AlertDialog.AlertDialogContent className={styles.content}>
+            <AlertDialog.AlertDialogTitle className={styles.title}>Delete resource?</AlertDialog.AlertDialogTitle>
+            <AlertDialog.AlertDialogDescription className={styles.description}>
               This action is permanent and cannot be undone.
             </AlertDialog.AlertDialogDescription>
-            <div className={styles['actions']}>
-              <AlertDialog.AlertDialogCancel className={styles['secondary']}>Cancel</AlertDialog.AlertDialogCancel>
-              <AlertDialog.AlertDialogAction className={styles['danger']}>Delete</AlertDialog.AlertDialogAction>
+            <div className={styles.actions}>
+              <AlertDialog.AlertDialogCancel className={styles.secondary}>Cancel</AlertDialog.AlertDialogCancel>
+              <AlertDialog.AlertDialogAction className={styles.danger}>Delete</AlertDialog.AlertDialogAction>
             </div>
           </AlertDialog.AlertDialogContent>
         </AlertDialog.AlertDialogPortal>

--- a/packages/registry-internals/src/internal-primitives/dialog-guarded-async/dialog-guarded-async.tsx
+++ b/packages/registry-internals/src/internal-primitives/dialog-guarded-async/dialog-guarded-async.tsx
@@ -20,26 +20,26 @@ export default function DialogGuardedAsyncInternalExample() {
 
   return (
     <Dialog.Root open={open} onOpenChange={setOpen}>
-      <Dialog.Trigger className={styles['trigger']}>Delete project</Dialog.Trigger>
+      <Dialog.Trigger className={styles.trigger}>Delete project</Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Overlay className={styles['overlay']} />
+        <Dialog.Overlay className={styles.overlay} />
         <Dialog.Content
-          className={styles['content']}
+          className={styles.content}
           onEscapeKeyDown={(event) => {
             if (busy) event.preventDefault()
           }}
           onInteractOutside={(event) => {
             if (busy) event.preventDefault()
           }}>
-          <Dialog.Title className={styles['title']}>Delete project?</Dialog.Title>
-          <Dialog.Description className={styles['description']}>This action cannot be undone.</Dialog.Description>
-          <div className={styles['actions']}>
+          <Dialog.Title className={styles.title}>Delete project?</Dialog.Title>
+          <Dialog.Description className={styles.description}>This action cannot be undone.</Dialog.Description>
+          <div className={styles.actions}>
             <Dialog.Close asChild>
-              <button className={styles['secondary']} disabled={busy} type="button">
+              <button className={styles.secondary} disabled={busy} type="button">
                 Cancel
               </button>
             </Dialog.Close>
-            <button className={styles['danger']} disabled={busy} onClick={onConfirm} type="button">
+            <button className={styles.danger} disabled={busy} onClick={onConfirm} type="button">
               {busy ? 'Deleting...' : 'Delete'}
             </button>
           </div>

--- a/packages/registry-internals/src/internal-primitives/dropdown-menu-selection/dropdown-menu-selection.tsx
+++ b/packages/registry-internals/src/internal-primitives/dropdown-menu-selection/dropdown-menu-selection.tsx
@@ -10,22 +10,22 @@ export default function DropdownMenuSelectionInternalExample() {
 
   return (
     <DropdownMenu.Root>
-      <DropdownMenu.Trigger className={styles['trigger']}>View mode</DropdownMenu.Trigger>
+      <DropdownMenu.Trigger className={styles.trigger}>View mode</DropdownMenu.Trigger>
       <DropdownMenu.Portal>
-        <DropdownMenu.Content className={styles['content']} sideOffset={8}>
-          <DropdownMenu.Label className={styles['menuLabel']}>Display</DropdownMenu.Label>
+        <DropdownMenu.Content className={styles.content} sideOffset={8}>
+          <DropdownMenu.Label className={styles.menuLabel}>Display</DropdownMenu.Label>
           <DropdownMenu.RadioGroup onValueChange={(v) => setView(v as 'grid' | 'list')} value={view}>
-            <DropdownMenu.RadioItem className={styles['item']} value="grid">
+            <DropdownMenu.RadioItem className={styles.item} value="grid">
               Grid
             </DropdownMenu.RadioItem>
-            <DropdownMenu.RadioItem className={styles['item']} value="list">
+            <DropdownMenu.RadioItem className={styles.item} value="list">
               List
             </DropdownMenu.RadioItem>
           </DropdownMenu.RadioGroup>
-          <DropdownMenu.Separator className={styles['separator']} />
+          <DropdownMenu.Separator className={styles.separator} />
           <DropdownMenu.CheckboxItem
             checked={showDeleted}
-            className={styles['item']}
+            className={styles.item}
             onCheckedChange={(checked) => setShowDeleted(checked === true)}>
             Show deleted
           </DropdownMenu.CheckboxItem>

--- a/packages/registry-internals/src/internal-primitives/popover-side-aware/popover-side-aware.tsx
+++ b/packages/registry-internals/src/internal-primitives/popover-side-aware/popover-side-aware.tsx
@@ -6,22 +6,17 @@ import styles from './styles.module.css'
 export default function PopoverSideAwareInternalExample() {
   return (
     <Popover.Root>
-      <Popover.Trigger className={styles['trigger']}>Open filters</Popover.Trigger>
+      <Popover.Trigger className={styles.trigger}>Open filters</Popover.Trigger>
       <Popover.Portal>
-        <Popover.Content
-          align="start"
-          className={styles['content']}
-          collisionPadding={10}
-          side="bottom"
-          sideOffset={10}>
-          <h4 className={styles['title']}>Quick filters</h4>
-          <p className={styles['description']}>Uses side, align, offset, and collision padding.</p>
-          <div className={styles['chips']}>
+        <Popover.Content align="start" className={styles.content} collisionPadding={10} side="bottom" sideOffset={10}>
+          <h4 className={styles.title}>Quick filters</h4>
+          <p className={styles.description}>Uses side, align, offset, and collision padding.</p>
+          <div className={styles.chips}>
             <span>Recent</span>
             <span>Assigned</span>
             <span>Open</span>
           </div>
-          <Popover.Arrow className={styles['arrow']} />
+          <Popover.Arrow className={styles.arrow} />
         </Popover.Content>
       </Popover.Portal>
     </Popover.Root>

--- a/packages/registry-internals/src/internal-primitives/select-controlled/select-controlled.tsx
+++ b/packages/registry-internals/src/internal-primitives/select-controlled/select-controlled.tsx
@@ -9,19 +9,19 @@ export default function SelectControlledInternalExample() {
 
   return (
     <Select.Select value={value} onValueChange={setValue}>
-      <Select.SelectTrigger className={styles['trigger']}>
+      <Select.SelectTrigger className={styles.trigger}>
         <Select.SelectValue placeholder="Choose fruit" />
       </Select.SelectTrigger>
       <Select.SelectPortal>
-        <Select.SelectContent className={styles['content']} sideOffset={8}>
+        <Select.SelectContent className={styles.content} sideOffset={8}>
           <Select.SelectViewport>
-            <Select.SelectItem className={styles['item']} value="apple">
+            <Select.SelectItem className={styles.item} value="apple">
               <Select.SelectItemText>Apple</Select.SelectItemText>
             </Select.SelectItem>
-            <Select.SelectItem className={styles['item']} value="banana">
+            <Select.SelectItem className={styles.item} value="banana">
               <Select.SelectItemText>Banana</Select.SelectItemText>
             </Select.SelectItem>
-            <Select.SelectItem className={styles['item']} value="orange">
+            <Select.SelectItem className={styles.item} value="orange">
               <Select.SelectItemText>Orange</Select.SelectItemText>
             </Select.SelectItem>
           </Select.SelectViewport>

--- a/packages/registry-internals/src/internal-primitives/tooltip-delay-provider/tooltip-delay-provider.tsx
+++ b/packages/registry-internals/src/internal-primitives/tooltip-delay-provider/tooltip-delay-provider.tsx
@@ -7,9 +7,9 @@ export default function TooltipDelayProviderInternalExample() {
   return (
     <Tooltip.TooltipProvider delayDuration={500} skipDelayDuration={280}>
       <Tooltip.Tooltip>
-        <Tooltip.TooltipTrigger className={styles['trigger']}>Hover trigger</Tooltip.TooltipTrigger>
+        <Tooltip.TooltipTrigger className={styles.trigger}>Hover trigger</Tooltip.TooltipTrigger>
         <Tooltip.TooltipPortal>
-          <Tooltip.TooltipContent className={styles['content']} side="top" sideOffset={8}>
+          <Tooltip.TooltipContent className={styles.content} side="top" sideOffset={8}>
             Delayed tooltip with shared provider timings.
           </Tooltip.TooltipContent>
         </Tooltip.TooltipPortal>

--- a/packages/registry-ui/src/combobox/motion-combobox.tsx
+++ b/packages/registry-ui/src/combobox/motion-combobox.tsx
@@ -42,8 +42,8 @@ const MotionCombobox = React.forwardRef<
     return (
       <MotionPopover {...popoverProps} dir={direction}>
         <PopoverTrigger asChild>
-          <MotionButton ref={ref} {...popoverTrigger} variant={popoverTrigger?.['variant'] ?? 'dashed'}>
-            {popoverTrigger?.['children']}
+          <MotionButton ref={ref} {...popoverTrigger} variant={popoverTrigger?.variant ?? 'dashed'}>
+            {popoverTrigger?.children}
             {showSelected &&
               (resolvedValue ? (
                 Array.isArray(resolvedValue) && resolvedValue.length ? (


### PR DESCRIPTION
## Summary

- **duck-motion.mdx**: full rewrite removing old WAAPI/easing/anim API; documents `MotionProvider`, `useMotionConfig`, `IDuckMotion` namespace, stagger utilities, full transitions/presets system, reduced-motion API, backward-compat tokens
- **duck-variants.mdx**: updates types reference from flat exports to `Variants` namespace (`Variants.VariantProps`, `Variants.Props`, `Variants.Options`, etc.) + fixes button example import
- **lint**: applies `useLiteralKeys` unsafe biome fixes across duck-cli, duck-docs, duck-primitives, and other packages

## Test plan

- [x] `biome check .` — 0 diagnostics
- [x] `npx turbo run check-types` — passed in pre-push hook