### PR TITLE
docs(calendar): update type refs to namespace form

### DIFF
--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/use-time-picker.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/use-time-picker.mdx
@@ -37,10 +37,10 @@ function MyTimePicker() {
 
 | Prop | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `value` | `TimeValue` | - | Controlled time value |
-| `defaultValue` | `TimeValue` | `{ hour: 0, minute: 0 }` | Default time (uncontrolled) |
-| `onChange` | `(value: TimeValue) => void` | - | Called when time changes |
-| `hourCycle` | `HourCycle` | `'24'` | `'12'` or `'24'` hour display |
+| `value` | `Time.ITimeValue` | - | Controlled time value |
+| `defaultValue` | `Time.ITimeValue` | `{ hour: 0, minute: 0 }` | Default time (uncontrolled) |
+| `onChange` | `(value: Time.ITimeValue) => void` | - | Called when time changes |
+| `hourCycle` | `Time.IHourCycle` | `'24'` | `'12'` or `'24'` hour display |
 | `showSeconds` | `boolean` | `false` | Show the seconds field |
 | `minTime` | `TimeValue` | - | Minimum selectable time |
 | `maxTime` | `TimeValue` | - | Maximum selectable time |
@@ -55,9 +55,9 @@ function MyTimePicker() {
 
 | Property | Type | Description |
 | :--- | :--- | :--- |
-| `value` | `TimeValue` | Current time value `{ hour, minute, second? }` |
-| `focusedField` | `TimeField` | Currently focused field |
-| `hourCycle` | `HourCycle` | Active hour cycle |
+| `value` | `Time.ITimeValue` | Current time value `{ hour, minute, second? }` |
+| `focusedField` | `Time.ITimeField` | Currently focused field |
+| `hourCycle` | `Time.IHourCycle` | Active hour cycle |
 | `displayHour` | `number` | Hour adjusted for 12h display |
 | `displayAmPm` | `'AM' \| 'PM'` | Current AM/PM value |
 
@@ -65,7 +65,7 @@ function MyTimePicker() {
 
 | Method | Signature | Description |
 | :--- | :--- | :--- |
-| `setValue` | `(value: TimeValue) => void` | Set the full time value |
+| `setValue` | `(value: Time.ITimeValue) => void` | Set the full time value |
 | `setField` | `(field, value) => void` | Set a single field |
 | `increment` | `(field, delta?) => void` | Increment a field |
 | `decrement` | `(field, delta?) => void` | Decrement a field |
@@ -75,7 +75,7 @@ function MyTimePicker() {
 ### `getFieldProps`
 
 ```tsx
-getFieldProps(field: TimeField) => TimeFieldProps
+getFieldProps(field: Time.ITimeField) => TimeFieldProps
 ```
 
 Returns props to spread on each time field element:

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/02-adapter-pattern.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/02-adapter-pattern.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Lesson 2: Adapter Pattern"
-description: "Understanding DateAdapter<TDate> and how to plug in any date library."
+description: "Understanding Adapter.IDateAdapter<TDate> and how to plug in any date library."
 ---
 
 <Callout icon={<Lightbulb />}>
@@ -11,10 +11,10 @@ description: "Understanding DateAdapter<TDate> and how to plug in any date libra
 
 ## What is a date adapter?
 
-A date adapter is an object that implements the `DateAdapter<TDate>` interface. It tells the calendar engine how to perform date operations without coupling to any specific date library.
+A date adapter is an object that implements the `Adapter.IDateAdapter<TDate>` interface. It tells the calendar engine how to perform date operations without coupling to any specific date library.
 
 ```tsx showLineNumbers
-import type { DateAdapter } from '@gentleduck/calendar'
+import type { Adapter } from '@gentleduck/calendar'
 
 // TDate is a generic - it can be Date, Dayjs, DateTime, etc.
 // The adapter tells the engine how to work with that type
@@ -56,10 +56,10 @@ const formatted = adapter.format(today, { month: 'long', year: 'numeric' })  // 
 Let's build a dayjs adapter step by step:
 
 ```tsx showLineNumbers
-import type { DateAdapter } from '@gentleduck/calendar'
+import type { Adapter } from '@gentleduck/calendar'
 import dayjs, { type Dayjs } from 'dayjs'
 
-const dayjsAdapter: DateAdapter<Dayjs> = {
+const dayjsAdapter: Adapter.IDateAdapter<Dayjs> = {
   // Creation
   today: () => dayjs().startOf('day'),
   create: (y, m, d) => dayjs().year(y).month(m).date(d).startOf('day'),

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/index.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/course/index.mdx
@@ -15,7 +15,7 @@ This course takes you from zero to a fully styled, accessible calendar with date
 
 <Step>[Introduction](/docs/packages/duck-calendar/course/01-introduction) - Why we built the engine and what problems it solves</Step>
 
-<Step>[Adapter Pattern](/docs/packages/duck-calendar/course/02-adapter-pattern) - Understanding `DateAdapter<TDate>` and plugging in any date library</Step>
+<Step>[Adapter Pattern](/docs/packages/duck-calendar/course/02-adapter-pattern) - Understanding `Adapter.IDateAdapter<TDate>` and plugging in any date library</Step>
 
 <Step>[Building a Grid](/docs/packages/duck-calendar/course/03-building-a-grid) - Using `buildCalendarMonth` to generate and render month grids</Step>
 


### PR DESCRIPTION
## Summary

- `course/02-adapter-pattern.mdx`: `DateAdapter<TDate>` → `Adapter.IDateAdapter<TDate>` (description, body, custom adapter example)
- `api/use-time-picker.mdx`: `TimeValue`/`TimeField`/`HourCycle` → `Time.ITimeValue`/`Time.ITimeField`/`Time.IHourCycle` across Config and Return sections
- `course/index.mdx`: step description updated to use `Adapter.IDateAdapter<TDate>`

## Test plan

- [ ] Type names match current `@gentleduck/calendar` namespace exports (`Adapter`, `Time`)
- [ ] No broken references in docs site