### PR TITLE
docs(calendar): update index.mdx DateAdapter ref to Adapter.IDateAdapter

### DIFF
--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/index.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/index.mdx
@@ -11,7 +11,7 @@ description: "Headless, framework-agnostic calendar engine with date adapter pat
 
 <MermaidDiagram chart={`
 graph TD
-  A["Core (Pure Functions)"] --> B["DateAdapter&lt;TDate&gt;"]
+  A["Core (Pure Functions)"] --> B["Adapter.IDateAdapter&lt;TDate&gt;"]
   A --> C["Grid Builder"]
   A --> D["Selection Logic"]
   A --> E["Navigation"]
@@ -44,7 +44,7 @@ We built this to replace `react-day-picker`. The numbers speak for themselves:
 
 <Step>**Core** - Pure functions for grid building, selection logic, and navigation. No React, no state, no side effects.</Step>
 
-<Step>**Adapter** - A `DateAdapter<TDate>` interface that abstracts date operations. Ships with a zero-dependency `NativeAdapter` for `Date`. Plug in dayjs, date-fns, or Temporal when needed.</Step>
+<Step>**Adapter** - A `Adapter.IDateAdapter<TDate>` interface that abstracts date operations. Ships with a zero-dependency `NativeAdapter` for `Date`. Plug in dayjs, date-fns, or Temporal when needed.</Step>
 
 <Step>**React hooks** - `useCalendar`, `useTimePicker`, `useDateTime` manage state and produce prop getters you spread onto your elements.</Step>
 

--- a/packages/duck-variants/src/variants.ts
+++ b/packages/duck-variants/src/variants.ts
@@ -186,8 +186,8 @@ export function cva<TVariants extends Variants.VariantDefinitions>(
 
   return (props: Variants.Props<TVariants> = {} as Variants.Props<TVariants>): string => {
     const rawProps = props as Record<string, unknown>
-    const dynamicClassName = rawProps.className
-    const dynamicClass = rawProps.class
+    const dynamicClassName = rawProps['className']
+    const dynamicClass = rawProps['class']
     const hasDynamic = dynamicClassName != null || dynamicClass != null
 
     let cacheKey = ''


### PR DESCRIPTION
## Summary

- Update mermaid diagram node label on line 14 from `DateAdapter<TDate>` to `Adapter.IDateAdapter<TDate>`
- Update prose description in the Adapter step on line 47 to match the new namespace export
- Fix pre-existing TS4111 index-signature access errors in `duck-variants/src/variants.ts`

## Test plan

- [ ] `npx turbo run check-types` passes for all packages (pre-existing `@gentleduck/registry-build` failure is unrelated to these changes)
- [ ] MDX renders correctly in the docs site