### PR TITLE
docs(calendar): fix remaining CalendarWeek refs to Grid.ICalendarWeek

### DIFF
--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/selection.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/selection.mdx
@@ -43,17 +43,17 @@ Decorate an array of weeks with selection flags (`isSelected`, `isRangeStart`, `
 
 ```tsx
 applySelection(
-  weeks: CalendarWeek<TDate>[],
+  weeks: Grid.ICalendarWeek<TDate>[],
   adapter: Adapter.IDateAdapter<TDate>,
   mode: Selection.SelectionMode,
   selected: Selection.CalendarValue<TDate, M>,
   constraints?: Selection.ISelectionConstraints<TDate> // default: {}
-) => CalendarWeek<TDate>[]
+) => Grid.ICalendarWeek<TDate>[]
 ```
 
 | Param | Type | Description |
 | :--- | :--- | :--- |
-| `weeks` | `CalendarWeek<TDate>[]` | Raw weeks from `buildCalendarMonth` |
+| `weeks` | `Grid.ICalendarWeek<TDate>[]` | Raw weeks from `buildCalendarMonth` |
 | `adapter` | `Adapter.IDateAdapter<TDate>` | Date adapter |
 | `mode` | `Selection.SelectionMode` | Selection mode |
 | `selected` | `Selection.CalendarValue<TDate, M>` | Current selection |

--- a/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/use-calendar.mdx
+++ b/apps/duck-ui-docs/content/docs/packages/duck-calendar/api/use-calendar.mdx
@@ -62,7 +62,7 @@ const { state, actions, getDayProps, getGridProps, getNavProps, getHeaderProps, 
 | `value` | `Selection.CalendarValue<TDate, M>` | Current selection. Shape depends on mode |
 | `focusedDate` | `TDate` | Date with keyboard focus |
 | `viewMode` | `Calendar.ViewMode` | `'days'`, `'months'`, or `'years'` |
-| `weeks` | `CalendarWeek<TDate>[]` | Decorated weeks for the first month |
+| `weeks` | `Grid.ICalendarWeek<TDate>[]` | Decorated weeks for the first month |
 | `months` | `Grid.ICalendarMonth<TDate>[]` | All month grids (for multi-month) |
 | `weekdays` | `string[]` | Localized weekday labels (7 items) |
 | `canGoNext` | `boolean` | Forward navigation available (respects `toDate`) |


### PR DESCRIPTION
Missed CalendarWeek<TDate> refs in api/selection.mdx (applySelection) and api/use-calendar.mdx (state.weeks).