### PR TITLE
fix(release): strip workspace/catalog protocols before publish

### DIFF
--- a/.changeset/strip-publish-protocols.md
+++ b/.changeset/strip-publish-protocols.md
@@ -1,0 +1,20 @@
+---
+"@gentleduck/calendar": patch
+"@gentleduck/cli": patch
+"@gentleduck/docs": patch
+"@gentleduck/gen": patch
+"@gentleduck/hooks": patch
+"@gentleduck/iam": patch
+"@gentleduck/lazy": patch
+"@gentleduck/libs": patch
+"@gentleduck/motion": patch
+"@gentleduck/primitives": patch
+"@gentleduck/query": patch
+"@gentleduck/ttest": patch
+"@gentleduck/upload": patch
+"@gentleduck/variants": patch
+"@gentleduck/vim": patch
+"@gentleduck/registry-ui": patch
+---
+
+Strip `workspace:*` and `catalog:` protocol tokens from `devDependencies`/`dependencies`/`peerDependencies` of every public package before `changeset publish`. Previously published artifacts leaked these tokens into npm metadata, which broke strict resolvers (bun, deno) for downstream consumers. Adds `scripts/clean-publish.ts` and wires it into the root `release` script with a `git checkout` restore step so source remains workspace-friendly.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "ci": "bun run check && bun run lint:ws && bun run check-types && bun run test && bun run build",
-    "release": "bun run ci && changeset publish",
+    "release": "bun run ci && bun run scripts/clean-publish.ts && changeset publish && git checkout -- 'packages/*/package.json' 'apps/*/package.json' 'tooling/*/package.json'",
     "clean": "rimraf --glob \"**/dist\" \"**/.turbo\" \"**/.cache\" \"**/.next\" \"**/.velite\" \"**/coverage\" \"**/*.tsbuildinfo\"",
     "clean:all": "rimraf --glob \"**/dist\" \"**/.turbo\" \"**/.cache\" \"**/.next\" \"**/.velite\" \"**/coverage\" \"**/*.tsbuildinfo\" \"**/node_modules\"",
     "clean:git": "git clean -xdf -e .claude -e .vscode",

--- a/scripts/clean-publish.ts
+++ b/scripts/clean-publish.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env bun
+/**
+ * Strip `workspace:*` and `catalog:` references from devDependencies of every
+ * public package before `changeset publish` runs. npm/bun publish the file
+ * verbatim, so these protocol tokens leak into the registry and break strict
+ * resolvers (bun, deno).
+ *
+ * Run before publish:  bun run scripts/clean-publish.ts
+ * Restore source:       git checkout packages/*\/package.json apps/*\/package.json
+ */
+
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const ROOT = process.cwd()
+
+async function listWorkspacePackageJsons(): Promise<string[]> {
+  const roots = ['packages', 'apps', 'tooling']
+  const out: string[] = []
+  for (const root of roots) {
+    let entries: string[] = []
+    try {
+      entries = await readdir(join(ROOT, root))
+    } catch {
+      continue
+    }
+    for (const name of entries) {
+      out.push(join(ROOT, root, name, 'package.json'))
+    }
+  }
+  return out
+}
+
+function isProtocolValue(value: unknown): boolean {
+  if (typeof value !== 'string') return false
+  return value.startsWith('workspace:') || value.startsWith('catalog:')
+}
+
+async function clean(file: string) {
+  let raw: string
+  try {
+    raw = await readFile(file, 'utf8')
+  } catch {
+    return
+  }
+  let pkg: Record<string, unknown>
+  try {
+    pkg = JSON.parse(raw)
+  } catch {
+    return
+  }
+
+  if (pkg.private === true) return
+  if (!pkg.name || typeof pkg.name !== 'string') return
+
+  let changed = false
+
+  for (const field of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'] as const) {
+    const block = pkg[field] as Record<string, string> | undefined
+    if (!block) continue
+    for (const [dep, version] of Object.entries(block)) {
+      if (isProtocolValue(version)) {
+        delete block[dep]
+        changed = true
+      }
+    }
+    if (Object.keys(block).length === 0) delete pkg[field]
+  }
+
+  if (changed) {
+    await writeFile(file, `${JSON.stringify(pkg, null, 2)}\n`)
+    console.log(`cleaned: ${file.replace(`${ROOT}/`, '')}`)
+  }
+}
+
+async function main() {
+  const files = await listWorkspacePackageJsons()
+  for (const file of files) await clean(file)
+}
+
+await main()


### PR DESCRIPTION
## Summary

- Adds `scripts/clean-publish.ts` that strips `workspace:*` and `catalog:` protocol tokens from every public workspace package's `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies` before publish.
- Wires it into the root `release` script. After `changeset publish`, source is restored via `git checkout` so workspace refs stay intact for monorepo dev.
- Includes a bulk patch changeset bumping every package whose previously published artifact leaked these tokens, so the next release re-publishes them with clean metadata.

## Why

Published artifacts on npm currently ship metadata like:
- ` @gentleduck/motion@0.1.18` peerDep `@gentleduck/variants: workspace:*`
- `@gentleduck/variants@0.1.22` devDep `@gentleduck/tsdown-config: workspace:*`, `@types/node: catalog:`
- and more

\`changeset publish\` only resolves \`workspace:\*\` in \`dependencies\` and \`peerDependencies\` — \`devDependencies\` and other fields ship verbatim. Strict resolvers (bun, deno) reject these.

## Test plan

- [ ] CI green
- [ ] After merge + version PR + release run, verify `npm view @gentleduck/variants@<new> devDependencies` contains no \`workspace:\` / \`catalog:\` tokens
- [ ] Smoke install in a downstream bun project consuming `@gentleduck/variants` directly without overrides