### PR TITLE
fix(release): wire clean-publish into changesets action

### DIFF
--- a/.changeset/wire-clean-publish-in-action.md
+++ b/.changeset/wire-clean-publish-in-action.md
@@ -1,0 +1,20 @@
+---
+"@gentleduck/calendar": patch
+"@gentleduck/cli": patch
+"@gentleduck/docs": patch
+"@gentleduck/gen": patch
+"@gentleduck/hooks": patch
+"@gentleduck/iam": patch
+"@gentleduck/lazy": patch
+"@gentleduck/libs": patch
+"@gentleduck/motion": patch
+"@gentleduck/primitives": patch
+"@gentleduck/query": patch
+"@gentleduck/ttest": patch
+"@gentleduck/upload": patch
+"@gentleduck/variants": patch
+"@gentleduck/vim": patch
+"@gentleduck/registry-ui": patch
+---
+
+Re-publish with `clean-publish.ts` actually wired into the changesets action `publish:` step. The previous release used `bunx changeset publish` directly, bypassing the root `release` script. As a result `workspace:*` and `catalog:` tokens still leaked into devDependencies metadata for the artifacts published in this cycle. This release runs the cleanup inline before publish.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: bunx changeset publish
+          publish: bun run scripts/clean-publish.ts && bunx changeset publish && git checkout -- 'packages/*/package.json' 'apps/*/package.json' 'tooling/*/package.json'
           version: bun run version-packages
           title: "chore: version packages"
           commit: "chore: version packages"


### PR DESCRIPTION
## Summary

Last release bypassed clean-publish. The action ran \`bunx changeset publish\` directly. New \`@gentleduck/variants@0.1.23\` etc still ship \`workspace:*\` / \`catalog:\` tokens in \`devDependencies\`.

This PR inlines the cleanup directly in the action's \`publish:\` step + adds a re-publish changeset.

## Verify after merge

\`\`\`
npm view @gentleduck/variants devDependencies
\`\`\`

should not contain any \`workspace:*\` or \`catalog:\` tokens.