### PR TITLE
chore(gen): deprecate @gentleduck/gen -> nestia + typia

### DIFF
--- a/.changeset/deprecate-duck-gen.md
+++ b/.changeset/deprecate-duck-gen.md
@@ -1,0 +1,12 @@
+---
+"@gentleduck/gen": patch
+---
+
+Mark `@gentleduck/gen` as deprecated. Add `deprecated` field to `package.json`, prominent warning in `README.md`, and a deprecation Callout at the top of the docs intro page.
+
+Recommended replacements:
+
+- **[nestia](https://nestia.io/)** — typed `@TypedRoute` / `@TypedBody` / `@TypedQuery` / `@TypedParam` decorators, automatic SDK generation, Swagger.
+- **[typia](https://typia.io/)** — runtime validators, serializers, JSON schema generation via a TypeScript transformer plugin.
+
+After this version publishes, run `npm deprecate "@gentleduck/gen" "Use nestia (https://nestia.io) and typia (https://typia.io) instead"` to mark every existing version on the npm registry as deprecated.

--- a/apps/duck/content/docs/duck-gen/introduction.mdx
+++ b/apps/duck/content/docs/duck-gen/introduction.mdx
@@ -4,6 +4,22 @@ description: Type-safe API route and message key generator for TypeScript. Scans
 section: Getting Started
 order: 0
 ---
+
+<Callout type="warning">
+**`@gentleduck/gen` is deprecated and no longer maintained.** Use the
+NestJS-native toolchain instead — it covers the same surface (typed routes,
+typed bodies, runtime validation, SDK generation) with a real compiler
+transformer, full tooling, and an active community.
+
+- **[nestia](https://nestia.io/)** — typed `@TypedRoute` / `@TypedBody` /
+  `@TypedQuery` / `@TypedParam` decorators, automatic SDK generation, Swagger
+- **[typia](https://typia.io/)** — runtime validators, serializers, JSON
+  schema generation from TypeScript types via a TS transformer plugin
+
+Migration: replace `@Body(typiaBody<X>())` with `@TypedBody()`, `@Get()` with
+`@TypedRoute.Get()`. See the [nestia migration guide](https://nestia.io/docs/sdk/).
+</Callout>
+
 ## What is Duck Gen?
 
 Duck Gen is a **compiler extension** that reads your server source code and generates TypeScript

--- a/packages/duck-gen/README.md
+++ b/packages/duck-gen/README.md
@@ -1,5 +1,23 @@
 # @gentleduck/gen
 
+> [!WARNING]
+> **`@gentleduck/gen` is deprecated and no longer maintained.** Use the
+> NestJS-native toolchain instead — they cover the same surface (typed routes,
+> typed bodies, runtime validation, SDK generation) and ship with a real
+> compiler transformer, full tooling, and an active community.
+>
+> - **[nestia](https://nestia.io/)** — typed `@TypedRoute` / `@TypedBody` /
+>   `@TypedQuery` / `@TypedParam` decorators, automatic SDK generation, Swagger
+>   support
+> - **[typia](https://typia.io/)** — runtime validators, serializers, JSON
+>   schema generation, all from TypeScript types via a TS transformer plugin
+>
+> Migration is straightforward: replace `@Body(typiaBody<X>())` with
+> `@TypedBody()`, `@Get()` with `@TypedRoute.Get()`, etc. See the [nestia
+> migration guide](https://nestia.io/docs/sdk/) for details.
+
+---
+
 Duck Gen scans your TypeScript server code and generates type-safe route maps and
 message registries. It is currently tested with NestJS.
 

--- a/packages/duck-gen/package.json
+++ b/packages/duck-gen/package.json
@@ -18,7 +18,8 @@
     "typescript": "catalog:",
     "zod": "catalog:"
   },
-  "description": "Type-safe API and message generator for TypeScript projects (NestJS-tested).",
+  "description": "[DEPRECATED] Use nestia (https://nestia.io) and typia (https://typia.io) instead. Type-safe API and message generator for TypeScript projects (NestJS-tested).",
+  "deprecated": "@gentleduck/gen is no longer maintained. Migrate to nestia (https://nestia.io) for typed routes/SDK and typia (https://typia.io) for runtime validators — both ship as proper TS transformer plugins with active maintenance.",
   "devDependencies": {
     "@gentleduck/tsdown-config": "workspace:*",
     "@gentleduck/typescript-config": "workspace:*",


### PR DESCRIPTION
## Summary

Marks \`@gentleduck/gen\` as deprecated.

- \`package.json\` gets a \`deprecated\` field (npm shows banner on install)
- README has prominent warning at top
- Docs introduction page has a Callout pointing to alternatives
- Bulk patch changeset for one final release

## Recommended replacements

- **[nestia](https://nestia.io/)** — typed \`@TypedRoute\` / \`@TypedBody\` / \`@TypedQuery\` / \`@TypedParam\` decorators, automatic SDK generation, Swagger
- **[typia](https://typia.io/)** — runtime validators, serializers, JSON schema generation from TS types

## After merge + publish

\`\`\`
npm deprecate "@gentleduck/gen" "Use nestia (https://nestia.io) + typia (https://typia.io) instead"
\`\`\`

Run interactively (needs \`npm login\`) to mark every published version as deprecated on the registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Package @gentleduck/gen marked as deprecated and no longer actively maintained
  * Deprecation notices prominently displayed in package metadata, README, and documentation
  * Alternative tooling options (nestia, typia) recommended as replacements
  * Migration guidance provided including code transition examples for existing implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->