### PR TITLE
fix(primitives): block dangerouslySetInnerHTML through Slot merge [P1]

### DIFF
--- a/packages/duck-primitives/src/slot/__test__/slot.test.tsx
+++ b/packages/duck-primitives/src/slot/__test__/slot.test.tsx
@@ -126,3 +126,33 @@ describe('Slot (edge cases)', () => {
     expect(container.textContent).toBe('just text')
   })
 })
+
+describe('Slot (security)', () => {
+  it('drops dangerouslySetInnerHTML supplied by a Slot child', () => {
+    const { container } = render(
+      <Slot>
+        <div dangerouslySetInnerHTML={{ __html: '<img src=x onerror=alert(1)>' }} />
+      </Slot>,
+    )
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.innerHTML).not.toContain('onerror')
+  })
+
+  it('still merges legitimate onClick and className when child is sanitized', () => {
+    const slotClick = mock(() => {})
+    const childClick = mock(() => {})
+    const { container } = render(
+      <Slot className="slot-class" onClick={slotClick}>
+        <button className="child-class" onClick={childClick}>
+          safe
+        </button>
+      </Slot>,
+    )
+    const button = container.querySelector('button')!
+    expect(button.className).toContain('slot-class')
+    expect(button.className).toContain('child-class')
+    button.click()
+    expect(childClick).toHaveBeenCalledTimes(1)
+    expect(slotClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/duck-primitives/src/slot/slot.tsx
+++ b/packages/duck-primitives/src/slot/slot.tsx
@@ -106,6 +106,10 @@ const Slottable = createSlottable('Slottable')
 
 type AnyProps = { ref?: React.Ref<unknown> | undefined; [key: string]: unknown }
 
+// Props a Slot child must never forward onto the cloned node. The Slot owns its
+// content rendering, so `asChild` cannot be used as a raw-HTML injection vector.
+const FORBIDDEN_SLOT_PROPS = ['dangerouslySetInnerHTML'] as const
+
 function isSlottable(child: React.ReactNode): child is React.ReactElement<ISlot.ISlottableProps, typeof Slottable> {
   return (
     React.isValidElement(child) &&
@@ -140,7 +144,16 @@ function mergeProps(slotProps: AnyProps, childProps: AnyProps) {
     }
   }
 
-  return { ...slotProps, ...overrideProps }
+  const merged = { ...slotProps, ...overrideProps }
+
+  // Force-override forbidden props to `undefined`: deleting the key is not enough
+  // because `cloneElement` keeps any key absent from the new props, which would
+  // leave a child's original `dangerouslySetInnerHTML` intact on the clone.
+  for (const forbidden of FORBIDDEN_SLOT_PROPS) {
+    merged[forbidden] = undefined
+  }
+
+  return merged
 }
 
 // React 18 warns on `element.props.ref`; React 19 warns on `element.ref`.


### PR DESCRIPTION
Security audit chain — P2 of 4. Follows P1 (#473).