### PR TITLE
feat(docs): wire @gentleduck/ttest into Packages nav

### DIFF
--- a/apps/duck/config/nav-items.ts
+++ b/apps/duck/config/nav-items.ts
@@ -14,6 +14,7 @@ import {
   Palette,
   ScrollText,
   Sparkles,
+  TestTube2,
   Terminal,
   Upload,
 } from 'lucide-react'
@@ -110,6 +111,13 @@ export const navItems = [
         icon: Command,
         color: '#f43f5e',
         status: 'deprecated',
+      },
+      {
+        title: '@gentleduck/ttest',
+        href: '/duck-ttest',
+        description: 'Type-level test framework and utility library. Zero runtime cost.',
+        icon: TestTube2,
+        color: '#0ea5e9',
       },
       {
         title: '@gentleduck/ttlog',


### PR DESCRIPTION
## Summary
- Adds the missing `@gentleduck/ttest` entry to `apps/duck/config/nav-items.ts` so it appears in the Packages menu between `@gentleduck/shortcut` and `@gentleduck/ttlog`.
- Uses `TestTube2` icon (lucide) and color `#0ea5e9`.
- Description: "Type-level test framework and utility library. Zero runtime cost."

The route pages, sidebar, velite collection, and `.gentleduck/duckTtest.json` data file were already in place from PR #493; only the nav menu wiring was missing.

## Test plan
- [ ] Visit the site, open the Packages nav, confirm `@gentleduck/ttest` is listed and links to `/duck-ttest`
- [ ] Confirm icon and color render correctly
- [ ] `bun run check-types` passes