### PR TITLE
style(docs): sort lucide imports alphabetically (Biome)

### DIFF
--- a/apps/duck/config/nav-items.ts
+++ b/apps/duck/config/nav-items.ts
@@ -14,8 +14,8 @@ import {
   Palette,
   ScrollText,
   Sparkles,
-  TestTube2,
   Terminal,
+  TestTube2,
   Upload,
 } from 'lucide-react'
 


### PR DESCRIPTION
## Summary
- Fixes the Release workflow lint failure on master after #495 merged.
- Reorders `TestTube2` and `Terminal` so the lucide import block stays alphabetical (Biome `useSortedKeys` / organize-imports).

## Test plan
- [ ] `bun run check` passes locally (no errors)
- [ ] Release workflow on master goes green after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code organization for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gentleeduck/duck-ui/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->