### PR TITLE
docs(duck-iam): sync API renames across all documentation

### DIFF
--- a/apps/duck/app/(app)/(docs)/duck-auth/page.tsx
+++ b/apps/duck/app/(app)/(docs)/duck-auth/page.tsx
@@ -18,7 +18,7 @@ const description =
 const features = [
   {
     icon: ShieldCheck,
-    title: '14-facet AuthRoot',
+    title: '14-facet AuthEngine',
     description:
       'One typed root exposes sessions, identities, passwords, providers, MFA, flows, API keys, M2M, orgs, idempotency, hijack policy, and anomaly detection.',
     bg: 'bg-emerald-500/10',
@@ -52,7 +52,7 @@ const features = [
     icon: Fingerprint,
     title: 'Production posture',
     description:
-      'AuthRoot.strict() rejects insecure config at boot — no NoopLimiter, no MemoryAdapter, no insecure cookies. Compliance presets for GDPR / SOC2 / HIPAA / FIPS.',
+      'AuthEngine.strict() rejects insecure config at boot — no NoopLimiter, no MemoryAdapter, no insecure cookies. Compliance presets for GDPR / SOC2 / HIPAA / FIPS.',
     bg: 'bg-orange-500/10',
     color: 'text-orange-500',
   },
@@ -147,7 +147,7 @@ export default async function DuckAuthPage() {
         <div>
           <div className="mb-8 flex flex-col items-center gap-1 text-center">
             <h2 className="font-semibold text-xl leading-tight tracking-tight">Install</h2>
-            <p className="text-muted-foreground text-sm">Scaffold a starter, or wire AuthRoot by hand.</p>
+            <p className="text-muted-foreground text-sm">Scaffold a starter, or wire AuthEngine by hand.</p>
           </div>
           <div className="relative mx-auto max-w-2xl">
             <CopyButton value={INSTALL_CODE} variant="ghost" className="absolute top-3 right-3" />

--- a/apps/duck/config/sidebars/duck-iam.ts
+++ b/apps/duck/config/sidebars/duck-iam.ts
@@ -88,7 +88,7 @@ export const duckIamSidebar = defineSidebar([
         collapsible: true,
         defaultOpen: false,
         items: [
-          { title: 'createAccessConfig()', href: '/duck-iam/advanced/config/access-config' },
+          { title: 'createIam()', href: '/duck-iam/advanced/config/access-config' },
           { title: 'Methods reference', href: '/duck-iam/advanced/config/methods' },
           { title: 'Typed context', href: '/duck-iam/advanced/config/context' },
           { title: 'Typed $-references', href: '/duck-iam/advanced/config/dollar-paths' },

--- a/apps/duck/content/docs/duck-auth/adapters/index.mdx
+++ b/apps/duck/content/docs/duck-auth/adapters/index.mdx
@@ -43,9 +43,9 @@ Every shipped adapter passes the same compliance test matrix exported from:
 
 ```typescript
 import {
-  runCredentialStoreCompliance,
-  runIdentityStoreCompliance,
-  runSessionStoreCompliance,
+  authRunCredentialStoreCompliance,
+  authRunIdentityStoreCompliance,
+  authRunSessionStoreCompliance,
 } from '@gentleduck/auth/adapters/__compliance__'
 ```
 
@@ -87,9 +87,9 @@ A custom adapter is any object that implements the three (or four) store
 interfaces. The most ergonomic path is the **SQL bridge**:
 
 ```typescript
-import { createSqlAuthStores } from '@gentleduck/auth/adapters/sql'
+import { authCreateSqlStores } from '@gentleduck/auth/adapters/sql'
 
-const stores = createSqlAuthStores({
+const stores = authCreateSqlStores({
   bridge: myDrizzleBridge,    // your SqlBridge.IBridge implementation
 })
 

--- a/apps/duck/content/docs/duck-auth/adapters/memory.mdx
+++ b/apps/duck/content/docs/duck-auth/adapters/memory.mdx
@@ -10,7 +10,7 @@ section: Adapters
 in-process `Map<string, T>` instances. Use it for:
 
 - Local development (no database setup required).
-- Unit / integration tests (`createTestAuth` uses it under the hood).
+- Unit / integration tests (`authCreateTest` uses it under the hood).
 - Storybook decorators.
 - Demos and examples.
 

--- a/apps/duck/content/docs/duck-auth/adapters/redis.mdx
+++ b/apps/duck/content/docs/duck-auth/adapters/redis.mdx
@@ -1,6 +1,6 @@
 ---
 title: Redis adapter bundle
-description: Production session store + idempotency cache + DPoP nonce store + sliding-window limiter + cross-process events. Works against ioredis, @upstash/redis, or an in-tree FakeRedis.
+description: Production session store + idempotency cache + DPoP nonce store + sliding-window limiter + cross-process events. Works against ioredis, @upstash/redis, or an in-tree AuthFakeRedis.
 section: Adapters
 ---
 
@@ -16,8 +16,8 @@ you pick the stores you need:
 | `AuthRedisIdempotencyStore` | The default in-memory `idempotency` cache. |
 | `AuthRedisDPoPNonceStore` | `MemoryDPoPNonceStore`. |
 | `AuthRedisLimiter` | `AuthMemoryLimiter`. |
-| `AuthRedisEvents` | `InMemoryEvents`. |
-| `FakeRedis` | A test-only in-memory `RedisLike.IClient`. |
+| `AuthRedisEvents` | `AuthInMemoryEvents`. |
+| `AuthFakeRedis` | A test-only in-memory `AuthRedisLike.IClient`. |
 
 Identities, credentials, and orgs **do not** belong in Redis - use the
 SQL bridge for durable rows and Redis for the volatile state that needs
@@ -34,10 +34,10 @@ import {
   AuthRedisLimiter,
   AuthRedisSessionStore,
 } from '@gentleduck/auth/adapters/redis'
-import { createSqlAuthStores } from '@gentleduck/auth/adapters/sql'
+import { authCreateSqlStores } from '@gentleduck/auth/adapters/sql'
 
 const redis = new Redis(process.env.REDIS_URL!)
-const sql = createSqlAuthStores({ bridge: myDrizzleBridge })
+const sql = authCreateSqlStores({ bridge: myDrizzleBridge })
 
 export const auth = new AuthEngine({
   stores: {
@@ -67,7 +67,7 @@ const auth = new AuthEngine({
 })
 ```
 
-`RedisLike.IClient` is the abstraction - any Redis client that exposes
+`AuthRedisLike.IClient` is the abstraction - any Redis client that exposes
 `get`, `set`, `del`, `incr`, `expire`, `pttl`, `keys`, `multi`,
 `subscribe`/`publish` works.
 
@@ -140,15 +140,15 @@ Use cases:
   active right now?").
 - Streaming to an audit log SaaS without a queueing layer.
 
-## FakeRedis (for tests)
+## AuthFakeRedis (for tests)
 
 ```typescript
-import { FakeRedis } from '@gentleduck/auth/adapters/redis'
+import { AuthFakeRedis } from '@gentleduck/auth/adapters/redis'
 
-const redis = new FakeRedis()
+const redis = new AuthFakeRedis()
 const limiter = new AuthRedisLimiter(redis)
 
-// FakeRedis implements the same RedisLike.IClient interface as ioredis,
+// AuthFakeRedis implements the same AuthRedisLike.IClient interface as ioredis,
 // but stores in-process. No Docker, no `redis-server`, no port to bind.
 ```
 

--- a/apps/duck/content/docs/duck-auth/adapters/sql.mdx
+++ b/apps/duck/content/docs/duck-auth/adapters/sql.mdx
@@ -9,12 +9,12 @@ section: Adapters
 duck-auth does not ship a Drizzle or Prisma adapter as a hard dependency.
 Instead, it exposes a thin contract - `SqlBridge.IBridge` - that any ORM
 can implement. The bridge is then wrapped into the four stores
-(identities / credentials / sessions / orgs) by `createSqlAuthStores`.
+(identities / credentials / sessions / orgs) by `authCreateSqlStores`.
 
 ```typescript
-import { createSqlAuthStores } from '@gentleduck/auth/adapters/sql'
+import { authCreateSqlStores } from '@gentleduck/auth/adapters/sql'
 
-const stores = createSqlAuthStores({ bridge })
+const stores = authCreateSqlStores({ bridge })
 
 export const auth = new AuthEngine({
   stores: {
@@ -42,7 +42,7 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL })
 const db = drizzle(pool)
 
 const bridge = createDrizzlePgBridge(db, schema)   // schema = your Drizzle tables
-const stores = createSqlAuthStores({ bridge })
+const stores = authCreateSqlStores({ bridge })
 ```
 
 Equivalent imports for MySQL and SQLite:

--- a/apps/duck/content/docs/duck-auth/advanced/cli.mdx
+++ b/apps/duck/content/docs/duck-auth/advanced/cli.mdx
@@ -54,7 +54,7 @@ Output:
 [v] baseUrl set: https://api.example.com
 [v] transport: JwtTransport with 2 verify keys
 [v] limiter: AuthRedisLimiter
-[x] events: InMemoryEvents - strict() requires cross-process delivery in production
+[x] events: AuthInMemoryEvents - strict() requires cross-process delivery in production
 [x] no listener attached to 'lockout' event
 
 2 failed gates. Run `duck-auth doctor --explain` for fix suggestions.

--- a/apps/duck/content/docs/duck-auth/advanced/i18n.mdx
+++ b/apps/duck/content/docs/duck-auth/advanced/i18n.mdx
@@ -1,6 +1,6 @@
 ---
 title: Internationalisation
-description: I18nMessageCatalog (zero-dep) + LinguiResolver. Translate every AUTH/* error code and channel template.
+description: AuthI18nMessageCatalog (zero-dep) + AuthLinguiResolver. Translate every AUTH/* error code and channel template.
 section: Advanced
 ---
 
@@ -15,14 +15,14 @@ Two surfaces in duck-auth produce user-facing strings:
 
 duck-auth ships a resolver-agnostic facet for both.
 
-## Built-in: `I18nMessageCatalog`
+## Built-in: `AuthI18nMessageCatalog`
 
 Zero dependencies. Define your messages inline:
 
 ```typescript
-import { I18nMessageCatalog } from '@gentleduck/auth/i18n'
+import { AuthI18nMessageCatalog } from '@gentleduck/auth/i18n'
 
-const i18n = new I18nMessageCatalog({
+const i18n = new AuthI18nMessageCatalog({
   defaultLocale: 'en',
   messages: {
     en: {
@@ -80,17 +80,17 @@ The `code` stays stable on the wire (for client-side branching); the
 
 ## Lingui adapter
 
-For apps already using `@lingui/core`, the `LinguiResolver` plugs in:
+For apps already using `@lingui/core`, the `AuthLinguiResolver` plugs in:
 
 ```typescript
 import { i18n as lingui } from '@lingui/core'
-import { LinguiResolver } from '@gentleduck/auth/i18n'
+import { AuthLinguiResolver } from '@gentleduck/auth/i18n'
 
 lingui.load('en', enMessages)
 lingui.load('es', esMessages)
 lingui.activate('en')
 
-const resolver = new LinguiResolver(lingui)
+const resolver = new AuthLinguiResolver(lingui)
 
 export const auth = new AuthEngine({
   i18n: { locale: 'en', catalog: resolver },
@@ -115,7 +115,7 @@ class CustomChannel implements AuthChannel.IChannel {
 }
 ```
 
-The shipped channels (`ConsoleChannel`, `SmtpChannel`, etc.) already
+The shipped channels (`AuthConsoleChannel`, `AuthSmtpChannel`, etc.) already
 call into the resolver - pass `i18n` to the channel constructor.
 
 ## Listing supported locales

--- a/apps/duck/content/docs/duck-auth/advanced/multi-tenancy.mdx
+++ b/apps/duck/content/docs/duck-auth/advanced/multi-tenancy.mdx
@@ -1,38 +1,38 @@
 ---
 title: Multi-tenancy
-description: withTenant + currentTenant - AsyncLocalStorage-backed tenant scope that flows through every facet, store, and event without threading TenantContext by hand.
+description: authWithTenant + authCurrentTenant - AsyncLocalStorage-backed tenant scope that flows through every facet, store, and event without threading AuthTenantContext by hand.
 section: Advanced
 ---
 
-duck-auth threads a `TenantContext` through every facet, store, and
+duck-auth threads a `AuthTenantContext` through every facet, store, and
 event so a multi-tenant app can reuse the same `AuthEngine` across
 tenants without leaking state between them. The two ways to scope a
 call are:
 
-1. **Explicit** - pass `TenantContext` as the last arg on every store
+1. **Explicit** - pass `AuthTenantContext` as the last arg on every store
    and facet call.
-2. **Ambient** - wrap a request in `withTenant(tenantId, fn)`; every
-   nested call sees `currentTenant()` resolve to the same value.
+2. **Ambient** - wrap a request in `authWithTenant(tenantId, fn)`; every
+   nested call sees `authCurrentTenant()` resolve to the same value.
 
 Ambient is usually right for HTTP / job runners; explicit is right
 for cross-tenant admin flows where one call legitimately spans
 several tenants.
 
 ```typescript
-import { withTenant, currentTenant, resolveTenant } from '@gentleduck/auth/core'
+import { authWithTenant, authCurrentTenant, authResolveTenant } from '@gentleduck/auth/core'
 ```
 
-## `withTenant`
+## `authWithTenant`
 
 Wrap a function (sync or async) so every awaitable inside it
 observes the supplied `tenantId`:
 
 ```typescript
-import { withTenant } from '@gentleduck/auth/core'
+import { authWithTenant } from '@gentleduck/auth/core'
 
 app.use((req, _res, next) => {
   const tenantId = extractTenantFromSubdomain(req.hostname)
-  withTenant(tenantId, () => next())
+  authWithTenant(tenantId, () => next())
 })
 ```
 
@@ -43,7 +43,7 @@ audit-visible rather than implicit.
 ```typescript
 // Daily job runner
 for (const tenant of tenants) {
-  await withTenant(tenant.id, () => runDailyJobsFor(tenant))
+  await authWithTenant(tenant.id, () => runDailyJobsFor(tenant))
 }
 ```
 
@@ -52,48 +52,48 @@ Every facet call inside the closure (`auth.identities.create`,
 ambient tenant before reaching the store - no manual threading
 required.
 
-## `currentTenant`
+## `authCurrentTenant`
 
-Read the active scope. Returns `undefined` when no `withTenant`
-wrapper is active, otherwise the `TenantContext` bound by the
+Read the active scope. Returns `undefined` when no `authWithTenant`
+wrapper is active, otherwise the `AuthTenantContext` bound by the
 nearest wrapper.
 
 ```typescript
-import { currentTenant } from '@gentleduck/auth/core'
+import { authCurrentTenant } from '@gentleduck/auth/core'
 
 function logWithTenant(message: string) {
-  const ctx = currentTenant()
+  const ctx = authCurrentTenant()
   logger.info({ tenantId: ctx?.tenantId, message })
 }
 ```
 
-Library code should prefer `resolveTenant` (below) which also
-considers a caller-supplied explicit `TenantContext`.
+Library code should prefer `authResolveTenant` (below) which also
+considers a caller-supplied explicit `AuthTenantContext`.
 
-## `resolveTenant`
+## `authResolveTenant`
 
-Pick the effective `TenantContext` for a single call. Explicit
+Pick the effective `AuthTenantContext` for a single call. Explicit
 caller-supplied context wins over the ALS ambient - so
-`withTenant` is a default, not a fence. Callers can still scope a
+`authWithTenant` is a default, not a fence. Callers can still scope a
 single call across a different tenant on purpose.
 
 ```typescript
-import { resolveTenant } from '@gentleduck/auth/core'
+import { authResolveTenant } from '@gentleduck/auth/core'
 
-async function readIdentityForAdmin(id: string, explicit?: TenantContext) {
-  const ctx = resolveTenant(explicit)
+async function readIdentityForAdmin(id: string, explicit?: AuthTenantContext) {
+  const ctx = authResolveTenant(explicit)
   return store.identities.findById(id, ctx)
 }
 ```
 
-Adapters use this pattern: they accept an explicit `TenantContext` on
+Adapters use this pattern: they accept an explicit `AuthTenantContext` on
 the public surface but fall back to the ALS ambient when none is
 passed. The user-supplied stores triple plugged into `AuthEngine.stores`
 must do the same to stay compatible with the ambient flow.
 
 ## Storage layer wiring
 
-Stores must accept a `TenantContext` last-arg on every method that
+Stores must accept a `AuthTenantContext` last-arg on every method that
 returns rows. The shipping memory / redis / SQL adapters do this
 already:
 
@@ -113,12 +113,12 @@ themselves; see [adapter custom guide](/duck-auth/adapters/#bringing-your-own).
 ### Subdomain-keyed tenants
 
 ```typescript
-import { withTenant } from '@gentleduck/auth/core'
+import { authWithTenant } from '@gentleduck/auth/core'
 import { auth } from './auth'
 
 app.use((req, res, next) => {
   const tenantId = req.hostname.split('.')[0] // 'acme' from 'acme.app.example'
-  withTenant(tenantId, () => next())
+  authWithTenant(tenantId, () => next())
 })
 
 // All routes downstream see auth.sessions.create() etc. scoped to `acme`
@@ -129,7 +129,7 @@ app.use((req, res, next) => {
 ```typescript
 app.use((req, _res, next) => {
   const tenantId = req.headers['x-tenant-id'] as string | undefined
-  withTenant(tenantId, () => next())
+  authWithTenant(tenantId, () => next())
 })
 ```
 
@@ -140,17 +140,17 @@ right after `resolveSession`:
 
 ```typescript
 const resolved = await auth.resolveSession({ headers: req.headers })
-await withTenant(resolved?.session.tenantId, () => handler(req, res))
+await authWithTenant(resolved?.session.tenantId, () => handler(req, res))
 ```
 
 ### Cross-tenant admin call
 
 When an admin route legitimately needs to query a different tenant,
-pass an explicit `TenantContext` and bypass the ambient:
+pass an explicit `AuthTenantContext` and bypass the ambient:
 
 ```typescript
 app.get('/admin/audit', async (req, res) => {
-  await withTenant('superadmin', async () => {
+  await authWithTenant('superadmin', async () => {
     // Inside the admin scope, but we want to read tenant-A's identities:
     const identity = await auth.identities.findById(req.query.id, { tenantId: 'tenant-a' })
     res.json(identity)
@@ -158,7 +158,7 @@ app.get('/admin/audit', async (req, res) => {
 })
 ```
 
-`resolveTenant({ tenantId: 'tenant-a' })` resolves to `tenant-a`
+`authResolveTenant({ tenantId: 'tenant-a' })` resolves to `tenant-a`
 regardless of the surrounding ALS scope.
 
 ## Strict-mode boot check
@@ -167,7 +167,7 @@ regardless of the surrounding ALS scope.
 itself - it's a single-vs-multi mode decision your app makes. When a
 preset adds tenancy enforcement (some compliance configs do), the
 check verifies that every facet call resolves a non-null
-`TenantContext` so a request that bypassed the ambient is rejected
+`AuthTenantContext` so a request that bypassed the ambient is rejected
 rather than silently leaking globals.
 
 ## See also

--- a/apps/duck/content/docs/duck-auth/advanced/oidc-op.mdx
+++ b/apps/duck/content/docs/duck-auth/advanced/oidc-op.mdx
@@ -20,10 +20,10 @@ distributed claims, RP-initiated logout.
 ## Quick start
 
 ```typescript
-import { createOidcOP, MemoryClientStore } from '@gentleduck/auth/oidc/op'
+import { authCreateOidcOP, AuthMemoryClientStore } from '@gentleduck/auth/oidc/op'
 
-const op = createOidcOP({
-  auth,                     // AuthEngine instance from defineAuth(...)
+const op = authCreateOidcOP({
+  auth,                     // AuthEngine instance from createAuth(...)
   config: {
     issuer: 'https://auth.example.com',
     supportedScopes: ['openid', 'profile', 'email', 'offline_access'],
@@ -81,13 +81,13 @@ The default memory stores are for dev. Production deployments wire a
 Drizzle adapter:
 
 ```typescript
-import { createDrizzlePgOidcOpStores } from '@gentleduck/auth/oidc/op/drizzle/pg'
+import { authCreateDrizzlePgOidcOpStores } from '@gentleduck/auth/oidc/op/drizzle/pg'
 
-const op = createOidcOP({
+const op = authCreateOidcOP({
   auth,
   config: { issuer, supportedScopes },
   signIdToken,
-  stores: createDrizzlePgOidcOpStores(db),
+  stores: authCreateDrizzlePgOidcOpStores(db),
 })
 ```
 
@@ -113,7 +113,7 @@ DCR is disabled by default. Enable it explicitly with a bearer gate so
 random Internet traffic cannot mint clients:
 
 ```typescript
-const op = createOidcOP({
+const op = authCreateOidcOP({
   auth,
   config: { issuer, supportedScopes },
   signIdToken,
@@ -128,7 +128,7 @@ const op = createOidcOP({
 Expose the registration endpoint and advertise it in discovery:
 
 ```typescript
-const discovery = buildOidcDiscovery({
+const discovery = authBuildOidcDiscovery({
   issuer,
   registrationEndpoint: `${issuer}/auth/oauth/register`,
 })

--- a/apps/duck/content/docs/duck-auth/advanced/oidc.mdx
+++ b/apps/duck/content/docs/duck-auth/advanced/oidc.mdx
@@ -27,9 +27,9 @@ automatically.
 ## Building the discovery document
 
 ```typescript
-import { buildOidcDiscovery } from '@gentleduck/auth/oidc'
+import { authBuildOidcDiscovery } from '@gentleduck/auth/oidc'
 
-const discovery = buildOidcDiscovery({
+const discovery = authBuildOidcDiscovery({
   issuer: 'https://api.example.com',
   prefix: '/auth',                 // default
   jwksPath: '/.well-known/jwks.json',  // default
@@ -124,7 +124,7 @@ The minimal OIDC issuer:
 
 ```typescript
 import { JwtTransport } from '@gentleduck/auth/core/transport'
-import { buildJwksHandler, buildOidcDiscovery } from '@gentleduck/auth/oidc'
+import { buildJwksHandler, authBuildOidcDiscovery } from '@gentleduck/auth/oidc'
 
 const transport = new JwtTransport({
   signKey: { kid: 'k1', key: signKey },
@@ -133,7 +133,7 @@ const transport = new JwtTransport({
   ttlMs: 15 * 60 * 1000,
 })
 
-const discovery = buildOidcDiscovery({
+const discovery = authBuildOidcDiscovery({
   issuer: 'https://api.example.com',
   signingAlgs: ['ES256'],
 })

--- a/apps/duck/content/docs/duck-auth/advanced/openapi.mdx
+++ b/apps/duck/content/docs/duck-auth/advanced/openapi.mdx
@@ -1,6 +1,6 @@
 ---
 title: OpenAPI generator
-description: buildOpenApiSpec + renderOpenApiYaml - emit an OpenAPI 3.1 spec for the mounted auth routes.
+description: authBuildOpenApiSpec + authRenderOpenApiYaml - emit an OpenAPI 3.1 spec for the mounted auth routes.
 section: Advanced
 ---
 
@@ -28,7 +28,7 @@ The simplest path:
 bunx @gentleduck/auth emit-openapi --out openapi.yaml
 ```
 
-The CLI loads your `auth.ts`, calls `buildOpenApiSpec`, and writes the
+The CLI loads your `auth.ts`, calls `authBuildOpenApiSpec`, and writes the
 result to disk.
 
 Flags:
@@ -41,10 +41,10 @@ Flags:
 ## Generate programmatically
 
 ```typescript
-import { buildOpenApiSpec, renderOpenApiYaml } from '@gentleduck/auth/openapi'
+import { authBuildOpenApiSpec, authRenderOpenApiYaml } from '@gentleduck/auth/openapi'
 import { auth } from './lib/auth'
 
-const spec = buildOpenApiSpec({
+const spec = authBuildOpenApiSpec({
   baseUrl: 'https://api.example.com',
   title: 'Example Auth',
   version: '1.0.0',
@@ -52,7 +52,7 @@ const spec = buildOpenApiSpec({
   providers: ['password', 'magic-link', 'google', 'github', 'passkey'],
 })
 
-console.log(renderOpenApiYaml(spec))
+console.log(authRenderOpenApiYaml(spec))
 ```
 
 Or write to disk:
@@ -60,7 +60,7 @@ Or write to disk:
 ```typescript
 import { writeFile } from 'node:fs/promises'
 
-const yaml = renderOpenApiYaml(spec)
+const yaml = authRenderOpenApiYaml(spec)
 await writeFile('openapi.yaml', yaml, 'utf-8')
 ```
 
@@ -120,10 +120,10 @@ For richer codegen (operations as fetch wrappers), try
 
 ## Customising the spec
 
-Override or add fields after `buildOpenApiSpec`:
+Override or add fields after `authBuildOpenApiSpec`:
 
 ```typescript
-const spec = buildOpenApiSpec({ baseUrl: '...', title: 'My API' })
+const spec = authBuildOpenApiSpec({ baseUrl: '...', title: 'My API' })
 
 spec.info.contact = { name: 'API team', email: 'api@example.com' }
 spec.info.license = { name: 'MIT', url: 'https://opensource.org/license/mit' }

--- a/apps/duck/content/docs/duck-auth/advanced/security.mdx
+++ b/apps/duck/content/docs/duck-auth/advanced/security.mdx
@@ -43,11 +43,11 @@ In **production** mode, `strict` rejects:
 
 - No listener attached to the `lockout` event. At minimum you should be
   paging on or auditing every lockout.
-- No `WebhookDeliverer` configured under SOC2 / HIPAA presets.
+- No `AuthWebhookDeliverer` configured under SOC2 / HIPAA presets.
 
 ### Compliance gates
 
-- HIPAA / FIPS without `Argon2idHasher`.
+- HIPAA / FIPS without `AuthArgon2idHasher`.
 - FIPS with `HS256` or `RS256` JWTs.
 - HIPAA / FIPS without `dataAtRest` encryption.
 - HIPAA without an audit-hooked channel.
@@ -144,13 +144,13 @@ bun audit
 ```typescript
 import Redis from 'ioredis'
 import {
-  Argon2idHasher,
+  AuthArgon2idHasher,
   ARGON2ID_COMPLIANCE,
   AuthEngine,
-  csrfGuard,
+  authCsrfGuard,
   hipaa,
-  impossibleTravelDetector,
-  WebhookDeliverer,
+  authImpossibleTravelDetector,
+  AuthWebhookDeliverer,
 } from '@gentleduck/auth/core'
 import { JwtTransport } from '@gentleduck/auth/core/transport'
 import {
@@ -159,12 +159,12 @@ import {
   AuthRedisLimiter,
   AuthRedisSessionStore,
 } from '@gentleduck/auth/adapters/redis'
-import { createSqlAuthStores } from '@gentleduck/auth/adapters/sql'
+import { authCreateSqlStores } from '@gentleduck/auth/adapters/sql'
 import { createDrizzlePgBridge } from '@gentleduck/auth/adapters/drizzle/pg'
 
 const redis = new Redis(process.env.REDIS_URL!)
 const drizzleBridge = createDrizzlePgBridge(db, schema)
-const sql = createSqlAuthStores({ bridge: drizzleBridge })
+const sql = authCreateSqlStores({ bridge: drizzleBridge })
 
 export const auth = new AuthEngine({
   ...hipaa({
@@ -174,7 +174,7 @@ export const auth = new AuthEngine({
       sessions: new AuthRedisSessionStore(redis),
     },
     events: new AuthRedisEvents(redis),
-    channels: { email: new SesChannel({ ... }) },
+    channels: { email: new AuthSesChannel({ ... }) },
   }),
   baseUrl: 'https://api.example.com',
   transport: new JwtTransport({
@@ -188,13 +188,13 @@ export const auth = new AuthEngine({
     refresh: { cookieName: '__Host-duck-refresh', ttlMs: 30 * 24 * 60 * 60 * 1000 },
   }),
   limiter: new AuthRedisLimiter(redis),
-  passwords: { hasher: new Argon2idHasher(ARGON2ID_COMPLIANCE) },
+  passwords: { hasher: new AuthArgon2idHasher(ARGON2ID_COMPLIANCE) },
 })
 
-auth.anomaly.register(impossibleTravelDetector({ ... }))
+auth.anomaly.register(authImpossibleTravelDetector({ ... }))
 auth.events.on('lockout', alertOpsTeam)
 
-const webhook = new WebhookDeliverer({
+const webhook = new AuthWebhookDeliverer({
   url: 'https://audit.example.com/auth',
   secret: process.env.WEBHOOK_SECRET!,
 })

--- a/apps/duck/content/docs/duck-auth/advanced/telemetry.mdx
+++ b/apps/duck/content/docs/duck-auth/advanced/telemetry.mdx
@@ -89,15 +89,15 @@ The SOC2 and HIPAA compliance presets configure OTel with the audit-log
 sink wired in. You get:
 
 - Every event emitted to OTel.
-- Every event also delivered via `WebhookDeliverer` to a signed audit
+- Every event also delivered via `AuthWebhookDeliverer` to a signed audit
   log endpoint.
 - PII redaction enforced at every layer.
 
 ```typescript
-import { soc2 } from '@gentleduck/auth/core'
+import { authApplyCompliancePreset } from '@gentleduck/auth/core'
 
-const cfg = soc2({ ... })
-// cfg.telemetry includes OtelInstrumentation; cfg.events.middleware includes the redaction layer.
+const cfg = authApplyCompliancePreset(base, 'soc2')
+// result.events.middleware includes the PII redaction layer.
 ```
 
 ## Dashboards

--- a/apps/duck/content/docs/duck-auth/advanced/testing.mdx
+++ b/apps/duck/content/docs/duck-auth/advanced/testing.mdx
@@ -1,16 +1,16 @@
 ---
 title: Testing
-description: createTestAuth() - a fluent builder with sensible defaults. Plus the adapter compliance suite for custom stores.
+description: authCreateTest() - a fluent builder with sensible defaults. Plus the adapter compliance suite for custom stores.
 section: Advanced
 ---
 
-## `createTestAuth()`
+## `authCreateTest()`
 
 ```typescript
-import { createTestAuth } from '@gentleduck/auth/test'
+import { authCreateTest } from '@gentleduck/auth/test'
 
-const auth = createTestAuth()
-// Defaults: AuthMemoryAdapter, BearerTransport, AuthMemoryLimiter, ScryptHasher.
+const auth = authCreateTest()
+// Defaults: AuthMemoryAdapter, BearerTransport, AuthMemoryLimiter, AuthScryptHasher.
 ```
 
 That's the entire setup for 90% of tests. Need to wire a real provider?
@@ -19,10 +19,10 @@ Pass it in:
 ```typescript
 import { password } from '@gentleduck/auth/providers/password'
 
-const auth = createTestAuth({
+const auth = authCreateTest({
   providers: [
     password({
-      passwords: undefined,  // filled in for you by createTestAuth
+      passwords: undefined,  // filled in for you by authCreateTest
       findIdentityByEmail: undefined,  // filled in for you
     }),
   ],
@@ -35,12 +35,12 @@ The factory wires the typed defaults so you don't repeat boilerplate.
 
 ```typescript
 import { describe, expect, it } from 'vitest'
-import { createTestAuth } from '@gentleduck/auth/test'
+import { authCreateTest } from '@gentleduck/auth/test'
 import { password } from '@gentleduck/auth/providers/password'
 
 describe('sign-in flow', () => {
   it('signs in with a valid password', async () => {
-    const auth = createTestAuth({
+    const auth = authCreateTest({
       providers: [password({})],
     })
 
@@ -66,7 +66,7 @@ describe('sign-in flow', () => {
   })
 
   it('rate-limits after 5 failed attempts', async () => {
-    const auth = createTestAuth({
+    const auth = authCreateTest({
       providers: [password({})],
       limiter: { max: 5, windowMs: 60_000 },
     })
@@ -94,7 +94,7 @@ rate-limit windows) can inject a clock:
 ```typescript
 const clock = { now: () => new Date('2026-05-27T10:00:00Z').getTime() }
 
-const auth = createTestAuth({ clock })
+const auth = authCreateTest({ clock })
 
 // Mint a magic link
 await auth.flows.beginPasswordReset({ email: 'ada@example.com' })
@@ -109,14 +109,14 @@ await expect(auth.flows.completePasswordReset({ token, newPassword: 'new' }))
 
 ## Capturing outbound channels
 
-Use `TestChannel` to assert on what was sent:
+Use `AuthTestChannel` to assert on what was sent:
 
 ```typescript
-import { TestChannel } from '@gentleduck/auth/channels/console'
+import { AuthTestChannel } from '@gentleduck/auth/channels/console'
 import { magicLink } from '@gentleduck/auth/providers/magic-link'
 
-const channel = new TestChannel({ kind: 'email' })
-const auth = createTestAuth({
+const channel = new AuthTestChannel({ kind: 'email' })
+const auth = authCreateTest({
   providers: [magicLink({ channels: { email: channel } })],
 })
 
@@ -137,18 +137,18 @@ If you write a custom adapter, run the compliance suite:
 
 ```typescript
 import {
-  runCredentialStoreCompliance,
-  runIdentityStoreCompliance,
-  runSessionStoreCompliance,
+  authRunCredentialStoreCompliance,
+  authRunIdentityStoreCompliance,
+  authRunSessionStoreCompliance,
 } from '@gentleduck/auth/adapters/__compliance__'
 import { describe } from 'vitest'
 
 import { MyCustomAdapter } from './my-adapter'
 
 describe('MyCustomAdapter', () => {
-  runIdentityStoreCompliance(() => new MyCustomAdapter().identities)
-  runSessionStoreCompliance(() => new MyCustomAdapter().sessions)
-  runCredentialStoreCompliance(() => new MyCustomAdapter().credentials)
+  authRunIdentityStoreCompliance(() => new MyCustomAdapter().identities)
+  authRunSessionStoreCompliance(() => new MyCustomAdapter().sessions)
+  authRunCredentialStoreCompliance(() => new MyCustomAdapter().credentials)
 })
 ```
 
@@ -159,15 +159,15 @@ that bite every adapter ever shipped. Every shipped adapter
 ## Storybook decorator
 
 ```tsx
-import { withAuth } from '@gentleduck/auth/client/react/storybook'
+import { authWithStorybook } from '@gentleduck/auth/client/react/storybook'
 
 export const SignIn = {
-  decorators: [withAuth({ baseUrl: '/auth', initialState: null })],
+  decorators: [authWithStorybook({ baseUrl: '/auth', initialState: null })],
   render: () => <SignInForm />,
 }
 
 export const Authed = {
-  decorators: [withAuth({
+  decorators: [authWithStorybook({
     baseUrl: '/auth',
     initialState: { session: ..., identity: ... },
   })],
@@ -184,9 +184,9 @@ For client-side tests that don't need a real server, point the client
 at a stub:
 
 ```typescript
-import { createAuthClient } from '@gentleduck/auth/client/vanilla'
+import { authCreateClient } from '@gentleduck/auth/client/vanilla'
 
-const client = createAuthClient({
+const client = authCreateClient({
   baseUrl: '',
   fetch: async (url, init) => {
     if (url === '/auth/signin') {

--- a/apps/duck/content/docs/duck-auth/advanced/webhooks.mdx
+++ b/apps/duck/content/docs/duck-auth/advanced/webhooks.mdx
@@ -1,23 +1,23 @@
 ---
 title: Webhooks
-description: WebhookDeliverer broadcasts AuthEngine events to HTTP endpoints with HMAC-signed bodies, exponential backoff, SSRF guards, and dead-letter sinks.
+description: AuthWebhookDeliverer broadcasts AuthEngine events to HTTP endpoints with HMAC-signed bodies, exponential backoff, SSRF guards, and dead-letter sinks.
 section: Advanced
 ---
 
-`WebhookDeliverer` fans out duck-auth events to one or more HTTPS
+`AuthWebhookDeliverer` fans out duck-auth events to one or more HTTPS
 endpoints. Every payload is HMAC-signed so receivers can verify
 authenticity, oversized bodies are dropped at 1 MiB, and the SSRF
 guard rejects loopback / private / link-local / cloud-metadata target
 hosts at construction.
 
 ```typescript
-import { WebhookDeliverer } from '@gentleduck/auth/core'
+import { AuthWebhookDeliverer } from '@gentleduck/auth/core'
 ```
 
 ## Setup
 
 ```typescript
-const webhooks = new WebhookDeliverer({
+const webhooks = new AuthWebhookDeliverer({
   endpoints: [
     {
       url: 'https://hooks.example.com/duck-auth',
@@ -84,17 +84,17 @@ HMAC-SHA256(secret, `${timestamp}.${body}`)
 ```
 
 `timestamp` is the same millis embedded in the payload. Sign with
-`signWebhookBody` on either side, verify with
-`verifyWebhookSignature` - both exported from the same module:
+`authSignWebhookBody` on either side, verify with
+`authVerifyWebhookSignature` - both exported from the same module:
 
 ```typescript
-import { signWebhookBody, verifyWebhookSignature } from '@gentleduck/auth/core'
+import { authSignWebhookBody, authVerifyWebhookSignature } from '@gentleduck/auth/core'
 
-// Sender side (typically you do not call this - WebhookDeliverer does)
-const sig = signWebhookBody(secret, body, timestamp)
+// Sender side (typically you do not call this - AuthWebhookDeliverer does)
+const sig = authSignWebhookBody(secret, body, timestamp)
 
 // Receiver side
-if (!verifyWebhookSignature(secret, body, signatureHeader, { timestamp, toleranceMs: 5 * 60_000 })) {
+if (!authVerifyWebhookSignature(secret, body, signatureHeader, { timestamp, toleranceMs: 5 * 60_000 })) {
   res.status(401).end()
   return
 }
@@ -129,7 +129,7 @@ of choice (SQS, Redis Stream, plain file) so an operator can replay
 later.
 
 ```typescript
-const sink: WebhookDeliverer.IDeadLetterSink = {
+const sink: AuthWebhookDeliverer.IDeadLetterSink = {
   async put(entry) {
     await redis.xadd('auth-webhook-dlq', '*', 'data', JSON.stringify(entry))
   },

--- a/apps/duck/content/docs/duck-auth/changelog.mdx
+++ b/apps/duck/content/docs/duck-auth/changelog.mdx
@@ -21,8 +21,8 @@ for the architectural rationale.
   with `MemoryDPoPNonceStore` and `AuthRedisDPoPNonceStore`.
 - **Adapters** - `AuthMemoryAdapter`, the Redis bundle
   (`AuthRedisSessionStore`, `AuthRedisLimiter`, `AuthRedisIdempotencyStore`,
-  `AuthRedisEvents`, `AuthRedisDPoPNonceStore`, `FakeRedis`), the SQL bridge
-  (`SqlBridge.IBridge`, `createSqlAuthStores`), and the Drizzle
+  `AuthRedisEvents`, `AuthRedisDPoPNonceStore`, `AuthFakeRedis`), the SQL bridge
+  (`SqlBridge.IBridge`, `authCreateSqlStores`), and the Drizzle
   reference implementations for pg / mysql / sqlite.
 - **Providers** - password, magic-link, six OAuth providers (Google,
   GitHub, LinkedIn, Microsoft, Discord, Apple), WebAuthn passkeys
@@ -37,10 +37,10 @@ for the architectural rationale.
 - **OpenAPI 3.1 generator**, **OIDC discovery + JWKS handler**,
   **OpenTelemetry instrumentation**, **i18n catalogs** (built-in +
   Lingui adapter).
-- **`createTestAuth()`** test helper, adapter compliance suite,
+- **`authCreateTest()`** test helper, adapter compliance suite,
   Storybook decorator.
 - **WebAuthn-MFA factor**.
-- **KMS-envelope `dataAtRest`** (`AwsKmsProvider` reference impl).
+- **KMS-envelope `dataAtRest`** (`AuthAwsKmsProvider` reference impl).
 - **`JwtTransport` live JWKS rotation**.
 
 ### Security baselines

--- a/apps/duck/content/docs/duck-auth/channels/console.mdx
+++ b/apps/duck/content/docs/duck-auth/channels/console.mdx
@@ -1,6 +1,6 @@
 ---
-title: ConsoleChannel
-description: Logs messages to stdout for development. Plus TestChannel (captures into an outbox) and NoopChannel (discards).
+title: AuthConsoleChannel
+description: Logs messages to stdout for development. Plus AuthTestChannel (captures into an outbox) and AuthNoopChannel (discards).
 section: Channels
 ---
 
@@ -8,18 +8,18 @@ section: Channels
 
 - **Development**: see magic-link URLs and password-reset codes printed
   directly in your terminal, without setting up SMTP.
-- **Tests**: `TestChannel` captures every send into an array for assertion.
-- **Benchmarks**: `NoopChannel` discards sends, so you measure
+- **Tests**: `AuthTestChannel` captures every send into an array for assertion.
+- **Benchmarks**: `AuthNoopChannel` discards sends, so you measure
   AuthEngine throughput without an outbound bottleneck.
 
-`ConsoleChannel` is never appropriate for production.
+`AuthConsoleChannel` is never appropriate for production.
 
-## ConsoleChannel
+## AuthConsoleChannel
 
 ```typescript
-import { ConsoleChannel } from '@gentleduck/auth/channels/console'
+import { AuthConsoleChannel } from '@gentleduck/auth/channels/console'
 
-const channel = new ConsoleChannel({
+const channel = new AuthConsoleChannel({
   kind: 'email',                       // | 'sms' | 'webpush'
   id: 'console',                       // shown in audit events
   sink: (line) => console.log(line),   // optional override
@@ -36,12 +36,12 @@ prints a JSON line:
 The `sink` override is useful in tests if you want to capture lines
 into a buffer instead of stdout.
 
-## TestChannel
+## AuthTestChannel
 
 ```typescript
-import { TestChannel } from '@gentleduck/auth/channels/console'
+import { AuthTestChannel } from '@gentleduck/auth/channels/console'
 
-const channel = new TestChannel({ kind: 'email' })
+const channel = new AuthTestChannel({ kind: 'email' })
 
 // ... run the test, trigger a provider send ...
 
@@ -56,12 +56,12 @@ channel.outbox = []  // clear between assertions
 
 The outbox is a public array; treat it as inspectable test state.
 
-## NoopChannel
+## AuthNoopChannel
 
 ```typescript
-import { NoopChannel } from '@gentleduck/auth/channels/console'
+import { AuthNoopChannel } from '@gentleduck/auth/channels/console'
 
-const channel = new NoopChannel({ kind: 'email' })
+const channel = new AuthNoopChannel({ kind: 'email' })
 ```
 
 Returns `{ ok: true, providerMessageId: 'noop:<incrementing>' }`

--- a/apps/duck/content/docs/duck-auth/channels/index.mdx
+++ b/apps/duck/content/docs/duck-auth/channels/index.mdx
@@ -28,13 +28,13 @@ Wire channels into providers that need outbound delivery (most notably
 
 ```typescript
 import { magicLink } from '@gentleduck/auth/providers/magic-link'
-import { ResendChannel } from '@gentleduck/auth/channels/resend'
-import { TwilioChannel } from '@gentleduck/auth/channels/twilio'
+import { AuthResendChannel } from '@gentleduck/auth/channels/resend'
+import { AuthTwilioChannel } from '@gentleduck/auth/channels/twilio'
 
 magicLink({
   channels: {
-    email: new ResendChannel({ apiKey: ..., from: 'no-reply@example.com' }),
-    sms: new TwilioChannel({ accountSid, authToken, from }),
+    email: new AuthResendChannel({ apiKey: ..., from: 'no-reply@example.com' }),
+    sms: new AuthTwilioChannel({ accountSid, authToken, from }),
   },
   // ...
 })
@@ -44,14 +44,14 @@ magicLink({
 
 | Channel | Import | Kind |
 | --- | --- | --- |
-| [`ConsoleChannel`](/duck-auth/channels/console) | `@gentleduck/auth/channels/console` | email / sms / webpush - dev |
-| [`SmtpChannel`](/duck-auth/channels/smtp) | `@gentleduck/auth/channels/smtp` | email - any nodemailer-compatible SMTP relay |
-| [`ResendChannel`](/duck-auth/channels/resend) | `@gentleduck/auth/channels/resend` | email - Resend transactional API |
-| [`SesChannel`](/duck-auth/channels/ses) | `@gentleduck/auth/channels/ses` | email - AWS SES |
-| [`TwilioChannel`](/duck-auth/channels/twilio) | `@gentleduck/auth/channels/twilio` | sms - Twilio Programmable Messaging |
-| [`WebPushChannel`](/duck-auth/channels/webpush) | `@gentleduck/auth/channels/webpush` | webpush - Web Push protocol with VAPID |
-| `TestChannel` | `@gentleduck/auth/channels/console` | captures sends into an outbox array - for tests |
-| `NoopChannel` | `@gentleduck/auth/channels/console` | discards sends, always returns ok - for benchmarks |
+| [`AuthConsoleChannel`](/duck-auth/channels/console) | `@gentleduck/auth/channels/console` | email / sms / webpush - dev |
+| [`AuthSmtpChannel`](/duck-auth/channels/smtp) | `@gentleduck/auth/channels/smtp` | email - any nodemailer-compatible SMTP relay |
+| [`AuthResendChannel`](/duck-auth/channels/resend) | `@gentleduck/auth/channels/resend` | email - Resend transactional API |
+| [`AuthSesChannel`](/duck-auth/channels/ses) | `@gentleduck/auth/channels/ses` | email - AWS SES |
+| [`AuthTwilioChannel`](/duck-auth/channels/twilio) | `@gentleduck/auth/channels/twilio` | sms - Twilio Programmable Messaging |
+| [`AuthWebPushChannel`](/duck-auth/channels/webpush) | `@gentleduck/auth/channels/webpush` | webpush - Web Push protocol with VAPID |
+| `AuthTestChannel` | `@gentleduck/auth/channels/console` | captures sends into an outbox array - for tests |
+| `AuthNoopChannel` | `@gentleduck/auth/channels/console` | discards sends, always returns ok - for benchmarks |
 
 ## Templating
 
@@ -94,9 +94,9 @@ enough; for full control, implement your own.
 ```typescript
 magicLink({
   channels: {
-    email: new ResendChannel({ ... }),
-    sms: new TwilioChannel({ ... }),
-    webpush: new WebPushChannel({ ... }),
+    email: new AuthResendChannel({ ... }),
+    sms: new AuthTwilioChannel({ ... }),
+    webpush: new AuthWebPushChannel({ ... }),
   },
 })
 

--- a/apps/duck/content/docs/duck-auth/channels/resend.mdx
+++ b/apps/duck/content/docs/duck-auth/channels/resend.mdx
@@ -1,5 +1,5 @@
 ---
-title: ResendChannel
+title: AuthResendChannel
 description: Resend.com transactional email channel.
 section: Channels
 ---
@@ -13,9 +13,9 @@ bun add resend
 ## Setup
 
 ```typescript
-import { ResendChannel } from '@gentleduck/auth/channels/resend'
+import { AuthResendChannel } from '@gentleduck/auth/channels/resend'
 
-const channel = new ResendChannel({
+const channel = new AuthResendChannel({
   apiKey: process.env.RESEND_API_KEY!,
   from: 'no-reply@example.com',
   id: 'resend',
@@ -38,11 +38,11 @@ auth.providers.use(
 
 ## Templating
 
-For branded emails, subclass `ResendChannel` and override
+For branded emails, subclass `AuthResendChannel` and override
 `renderMessage()` to produce the HTML / text body:
 
 ```typescript
-class BrandedResendChannel extends ResendChannel {
+class BrandedResendChannel extends AuthResendChannel {
   async renderMessage({ templateId, vars }) {
     switch (templateId) {
       case 'magic-link':

--- a/apps/duck/content/docs/duck-auth/channels/ses.mdx
+++ b/apps/duck/content/docs/duck-auth/channels/ses.mdx
@@ -14,11 +14,11 @@ bun add @aws-sdk/client-ses
 
 ```typescript
 import { SESClient } from '@aws-sdk/client-ses'
-import { SesChannel } from '@gentleduck/auth/channels/ses'
+import { AuthSesChannel } from '@gentleduck/auth/channels/ses'
 
 const client = new SESClient({ region: 'us-east-1' })
 
-const channel = new SesChannel({
+const channel = new AuthSesChannel({
   client,
   from: 'no-reply@example.com',
   id: 'ses',
@@ -87,7 +87,7 @@ app.post('/webhooks/ses', async (req, res) => {
 SES has account-level send rate (msg/s) and daily quotas. Once you
 leave the sandbox, quotas auto-scale based on reputation. duck-auth
 itself does not throttle outbound; if you push above SES limits,
-`SendEmail` returns `Throttling` and `SesChannel` raises
+`SendEmail` returns `Throttling` and `AuthSesChannel` raises
 `AUTH/RATE_LIMITED`.
 
 For backfill / bulk transactional (rare in auth flows), shard sends

--- a/apps/duck/content/docs/duck-auth/channels/smtp.mdx
+++ b/apps/duck/content/docs/duck-auth/channels/smtp.mdx
@@ -1,5 +1,5 @@
 ---
-title: SmtpChannel
+title: AuthSmtpChannel
 description: Nodemailer-compatible SMTP relay. Works with Postmark, Mailgun, custom SMTP servers - anywhere you have credentials.
 section: Channels
 ---
@@ -10,15 +10,15 @@ section: Channels
 bun add nodemailer
 ```
 
-`SmtpChannel` lazy-loads `nodemailer` - apps that don't use SMTP pay
+`AuthSmtpChannel` lazy-loads `nodemailer` - apps that don't use SMTP pay
 no cost.
 
 ## Setup
 
 ```typescript
-import { SmtpChannel } from '@gentleduck/auth/channels/smtp'
+import { AuthSmtpChannel } from '@gentleduck/auth/channels/smtp'
 
-const channel = new SmtpChannel({
+const channel = new AuthSmtpChannel({
   from: 'no-reply@example.com',
   host: 'smtp.example.com',
   port: 587,
@@ -51,10 +51,10 @@ auth.providers.use(
 
 The channel handles the SMTP delivery; rendering the message body is
 your responsibility. The default templates are minimal - for branded
-emails, subclass `SmtpChannel` and override `renderMessage()`:
+emails, subclass `AuthSmtpChannel` and override `renderMessage()`:
 
 ```typescript
-class BrandedSmtpChannel extends SmtpChannel {
+class BrandedSmtpChannel extends AuthSmtpChannel {
   async renderMessage({ templateId, vars }) {
     if (templateId === 'magic-link') {
       return {
@@ -100,7 +100,7 @@ better deliverability:
 
 ```typescript
 class MultiSmtpChannel implements AuthChannel.IChannel {
-  constructor(private channels: SmtpChannel[]) {}
+  constructor(private channels: AuthSmtpChannel[]) {}
   async send(input) {
     for (const ch of this.channels) {
       try {
@@ -114,5 +114,5 @@ class MultiSmtpChannel implements AuthChannel.IChannel {
 }
 ```
 
-Or shard by region / tenant - pass a different `SmtpChannel` per
+Or shard by region / tenant - pass a different `AuthSmtpChannel` per
 tenant if you have customer-specific routing.

--- a/apps/duck/content/docs/duck-auth/channels/twilio.mdx
+++ b/apps/duck/content/docs/duck-auth/channels/twilio.mdx
@@ -1,5 +1,5 @@
 ---
-title: TwilioChannel
+title: AuthTwilioChannel
 description: Twilio Programmable Messaging for SMS magic-link and MFA codes.
 section: Channels
 ---
@@ -13,9 +13,9 @@ bun add twilio
 ## Setup
 
 ```typescript
-import { TwilioChannel } from '@gentleduck/auth/channels/twilio'
+import { AuthTwilioChannel } from '@gentleduck/auth/channels/twilio'
 
-const channel = new TwilioChannel({
+const channel = new AuthTwilioChannel({
   accountSid: process.env.TWILIO_ACCOUNT_SID!,
   authToken: process.env.TWILIO_AUTH_TOKEN!,
   from: '+15005550006',   // your purchased Twilio phone number
@@ -63,7 +63,7 @@ Expires in 10 minutes.
 Customise by subclassing:
 
 ```typescript
-class BrandedTwilio extends TwilioChannel {
+class BrandedTwilio extends AuthTwilioChannel {
   async renderMessage({ templateId, vars }) {
     return {
       to: vars.phone,   // resolve from identity.profile.phone
@@ -89,7 +89,7 @@ maximise deliverability:
 For 6-digit MFA codes (TOTP / phone verification):
 
 ```typescript
-class MfaTwilio extends TwilioChannel {
+class MfaTwilio extends AuthTwilioChannel {
   async renderMessage({ templateId, vars }) {
     if (templateId === 'mfa-code') {
       return {

--- a/apps/duck/content/docs/duck-auth/channels/webpush.mdx
+++ b/apps/duck/content/docs/duck-auth/channels/webpush.mdx
@@ -1,5 +1,5 @@
 ---
-title: WebPushChannel
+title: AuthWebPushChannel
 description: Web Push protocol with VAPID. Deliver magic-link prompts to a user's existing browser tab without email.
 section: Channels
 ---
@@ -31,9 +31,9 @@ client (it's safe to expose); the private key stays server-side.
 ## Setup
 
 ```typescript
-import { WebPushChannel } from '@gentleduck/auth/channels/webpush'
+import { AuthWebPushChannel } from '@gentleduck/auth/channels/webpush'
 
-const channel = new WebPushChannel({
+const channel = new AuthWebPushChannel({
   vapidPublicKey: process.env.VAPID_PUBLIC_KEY!,
   vapidPrivateKey: process.env.VAPID_PRIVATE_KEY!,
   vapidSubject: 'mailto:admin@example.com',
@@ -128,6 +128,6 @@ try {
 }
 ```
 
-duck-auth's shipped `WebPushChannel` already removes 410-returning
+duck-auth's shipped `AuthWebPushChannel` already removes 410-returning
 subscriptions automatically - the manual handling is only needed if
 you subclass and override `send()`.

--- a/apps/duck/content/docs/duck-auth/client/index.mdx
+++ b/apps/duck/content/docs/duck-auth/client/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Client libraries
-description: Vanilla createAuthClient + React AuthProvider + hooks. Vue, Svelte, and Solid clients are also shipped.
+description: Vanilla authCreateClient + React AuthProvider + hooks. Vue, Svelte, and Solid clients are also shipped.
 section: Client
 ---
 
@@ -12,7 +12,7 @@ routes so your UI doesn't have to know the wire shape. They:
 - Track session state with `loading` / `authed` / `guest` semantics.
 - Provide a `signIn(providerId, input)` that handles the right HTTP
   method and surfaces typed errors.
-- Re-render reactive views (React `useSession`, Vue `useSession`,
+- Re-render reactive views (React `authUseSession`, Vue `authUseSession`,
   Svelte stores, Solid signals) when the session changes.
 - Subscribe to `session.rotated` / `session.revoked` so a sign-out in
   one tab signs you out in every tab.
@@ -22,9 +22,9 @@ routes so your UI doesn't have to know the wire shape. They:
 | Client | Import | Notes |
 | --- | --- | --- |
 | [Vanilla](/duck-auth/client/vanilla) | `@gentleduck/auth/client/vanilla` | Framework-agnostic. Zero dependencies. |
-| [React](/duck-auth/client/react) | `@gentleduck/auth/client/react` | `<AuthProvider>` + `useSession` + `useSignIn` + `useBeginProvider`. |
-| Vue | `@gentleduck/auth/client/vue` | `createAuth()` + `useSession`. |
-| Svelte | `@gentleduck/auth/client/svelte` | `createAuthStore()` reactive store. |
+| [React](/duck-auth/client/react) | `@gentleduck/auth/client/react` | `<AuthProvider>` + `authUseSession` + `authUseSignIn` + `authUseBeginProvider`. |
+| Vue | `@gentleduck/auth/client/vue` | `createAuth()` + `authUseSession`. |
+| Svelte | `@gentleduck/auth/client/svelte` | `authCreateStore()` reactive store. |
 | Solid | `@gentleduck/auth/client/solid` | `createAuthSignal()`. |
 
 ## Anatomy of a sign-in
@@ -59,10 +59,10 @@ Every client is generic over `Profile`:
 type Profile = { displayName: string; avatarUrl?: string }
 
 // Vanilla
-const client = createAuthClient<Profile>()
+const client = authCreateClient<Profile>()
 
-// React - pass through useSession's generic
-const { data } = useSession<Profile>()
+// React - pass through authUseSession's generic
+const { data } = authUseSession<Profile>()
 // data.identity.profile is typed as Profile
 ```
 
@@ -82,12 +82,12 @@ false` if you don't want it.
 ## Error handling
 
 All clients raise the typed `AuthError` (or a wire-equivalent
-`{ code, status, meta }` object on the React `useSignIn().error` field).
+`{ code, status, meta }` object on the React `authUseSignIn().error` field).
 Branch on `error.code`, not on HTTP status - codes are stable across
 versions.
 
 ```typescript
-const signIn = useSignIn()
+const signIn = authUseSignIn()
 
 await signIn.mutateAsync({ providerId: 'password', input: { email, password } })
 

--- a/apps/duck/content/docs/duck-auth/client/react.mdx
+++ b/apps/duck/content/docs/duck-auth/client/react.mdx
@@ -1,6 +1,6 @@
 ---
 title: React client
-description: <AuthProvider>, useSession, useSignIn, useSignOut, useBeginProvider. React 16.8+.
+description: <AuthProvider>, authUseSession, authUseSignIn, authUseSignOut, authUseBeginProvider. React 16.8+.
 section: Client
 ---
 
@@ -28,13 +28,13 @@ Props:
 | `initialState` | Hydrate from a server-rendered snapshot. Pair with `noInitialFetch: true`. |
 | `fetch` | Override the fetch implementation. |
 
-## `useSession`
+## `authUseSession`
 
 ```tsx
-import { useSession } from '@gentleduck/auth/client/react'
+import { authUseSession } from '@gentleduck/auth/client/react'
 
 function Header() {
-  const { data, status } = useSession()
+  const { data, status } = authUseSession()
 
   if (status === 'loading') return <Skeleton />
   if (status === 'guest') return <SignInButton />
@@ -59,17 +59,17 @@ Generic over `Profile`:
 ```tsx
 type Profile = { displayName: string; avatarUrl?: string }
 
-const { data, status } = useSession<Profile>()
+const { data, status } = authUseSession<Profile>()
 // data?.identity.profile.displayName  <- typed
 ```
 
-## `useSignIn`
+## `authUseSignIn`
 
 ```tsx
-import { useSignIn } from '@gentleduck/auth/client/react'
+import { authUseSignIn } from '@gentleduck/auth/client/react'
 
 function SignInForm() {
-  const signIn = useSignIn()
+  const signIn = authUseSignIn()
 
   return (
     <form
@@ -110,13 +110,13 @@ API:
 | `data` | The `{ session, identity }` from the last success. |
 | `reset()` | Clear `error` and `data`. |
 
-## `useSignOut`
+## `authUseSignOut`
 
 ```tsx
-import { useSignOut } from '@gentleduck/auth/client/react'
+import { authUseSignOut } from '@gentleduck/auth/client/react'
 
 function SignOutButton() {
-  const signOut = useSignOut()
+  const signOut = authUseSignOut()
   return (
     <button onClick={() => signOut.mutate()} disabled={signOut.isLoading}>
       Sign out
@@ -125,13 +125,13 @@ function SignOutButton() {
 }
 ```
 
-## `useBeginProvider`
+## `authUseBeginProvider`
 
 ```tsx
-import { useBeginProvider } from '@gentleduck/auth/client/react'
+import { authUseBeginProvider } from '@gentleduck/auth/client/react'
 
 function GoogleSignIn() {
-  const begin = useBeginProvider()
+  const begin = authUseBeginProvider()
   return (
     <button onClick={() => begin.mutate({ providerId: 'google', input: {} })}>
       Sign in with Google
@@ -140,7 +140,7 @@ function GoogleSignIn() {
 }
 
 function MagicLinkRequest() {
-  const begin = useBeginProvider()
+  const begin = authUseBeginProvider()
   return (
     <form
       onSubmit={async (e) => {
@@ -205,10 +205,10 @@ Now the first paint is already authenticated - no flash of guest UI.
 ## Storybook decorator
 
 ```tsx
-import { withAuth } from '@gentleduck/auth/client/react/storybook'
+import { authWithStorybook } from '@gentleduck/auth/client/react/storybook'
 
 export const MyStory = {
-  decorators: [withAuth({ baseUrl: '/auth' })],
+  decorators: [authWithStorybook({ baseUrl: '/auth' })],
   render: () => <SignInButton />,
 }
 ```
@@ -218,7 +218,7 @@ client, so your auth-aware components render without a real server.
 
 ## Errors
 
-The `error` field on `useSignIn` / `useSignOut` / `useBeginProvider` is
+The `error` field on `authUseSignIn` / `authUseSignOut` / `authUseBeginProvider` is
 a typed `AuthError`. Branch on `error.code`:
 
 ```tsx

--- a/apps/duck/content/docs/duck-auth/client/solid.mdx
+++ b/apps/duck/content/docs/duck-auth/client/solid.mdx
@@ -1,6 +1,6 @@
 ---
 title: Solid client
-description: SolidJS provider + hooks - useSession, useSignIn, useSignOut. Built on createSignal so updates are fine-grained.
+description: SolidJS provider + hooks - authUseSession, authUseSignIn, authUseSignOut. Built on createSignal so updates are fine-grained.
 section: Client
 ---
 
@@ -21,16 +21,16 @@ render(
 )
 ```
 
-`AuthProvider` accepts the same options as `createAuthClient` plus an optional
+`AuthProvider` accepts the same options as `authCreateClient` plus an optional
 `client` prop if you want to share an existing vanilla client.
 
-## `useSession`
+## `authUseSession`
 
 ```tsx
-import { useSession } from '@gentleduck/auth/client/solid'
+import { authUseSession } from '@gentleduck/auth/client/solid'
 
 function App() {
-  const { data, status } = useSession()
+  const { data, status } = authUseSession()
 
   return (
     <>
@@ -47,14 +47,14 @@ function App() {
 `data` and `status` are signals (call them to read). Updates are reactive and
 fine-grained so only the components that read them re-render.
 
-## `useSignIn` / `useSignOut`
+## `authUseSignIn` / `authUseSignOut`
 
 ```tsx
-import { useSignIn } from '@gentleduck/auth/client/solid'
+import { authUseSignIn } from '@gentleduck/auth/client/solid'
 import { createSignal } from 'solid-js'
 
 function SignInForm() {
-  const signIn = useSignIn()
+  const signIn = authUseSignIn()
   const [email, setEmail] = createSignal('')
   const [password, setPassword] = createSignal('')
 
@@ -114,5 +114,5 @@ discrimination:
 ## Reactivity across tabs
 
 The Solid client subscribes to `BroadcastChannel` updates from the vanilla
-client. Signing in or out in one tab updates the `useSession` signal in every
+client. Signing in or out in one tab updates the `authUseSession` signal in every
 other tab automatically.

--- a/apps/duck/content/docs/duck-auth/client/svelte.mdx
+++ b/apps/duck/content/docs/duck-auth/client/svelte.mdx
@@ -7,9 +7,9 @@ section: Client
 ## Setup
 
 ```typescript title="src/lib/auth.ts"
-import { createAuthStore } from '@gentleduck/auth/client/svelte'
+import { authCreateStore } from '@gentleduck/auth/client/svelte'
 
-export const auth = createAuthStore({
+export const auth = authCreateStore({
   baseUrl: '/auth',
 })
 
@@ -87,10 +87,10 @@ export const load: LayoutServerLoad = ({ locals }) => {
 ```
 
 ```typescript title="src/lib/auth.ts (client)"
-import { createAuthStore } from '@gentleduck/auth/client/svelte'
+import { authCreateStore } from '@gentleduck/auth/client/svelte'
 
 export function makeAuth(initialState: any) {
-  return createAuthStore({
+  return authCreateStore({
     baseUrl: '/auth',
     noInitialFetch: true,
     initialState,

--- a/apps/duck/content/docs/duck-auth/client/vanilla.mdx
+++ b/apps/duck/content/docs/duck-auth/client/vanilla.mdx
@@ -1,15 +1,15 @@
 ---
 title: Vanilla client
-description: Framework-agnostic createAuthClient. Promise-based signIn / signOut / getSession + onChange subscription.
+description: Framework-agnostic authCreateClient. Promise-based signIn / signOut / getSession + onChange subscription.
 section: Client
 ---
 
 ## Constructor
 
 ```typescript
-import { createAuthClient } from '@gentleduck/auth/client/vanilla'
+import { authCreateClient } from '@gentleduck/auth/client/vanilla'
 
-const client = createAuthClient({
+const client = authCreateClient({
   baseUrl: '/auth',              // default
   fetch: globalThis.fetch,       // override for SSR / Node tests
   headers: { 'X-App': 'web' },   // sent on every call
@@ -119,11 +119,11 @@ type State<Profile> =
 ## Constructing a Profile-typed client
 
 ```typescript
-import { createAuthClient } from '@gentleduck/auth/client/vanilla'
+import { authCreateClient } from '@gentleduck/auth/client/vanilla'
 
 type Profile = { displayName: string; avatarUrl?: string }
 
-export const client = createAuthClient<Profile>()
+export const client = authCreateClient<Profile>()
 // client.signIn -> Profile is inferred
 // client.onChange((state) => state?.identity.profile.displayName)
 ```
@@ -132,7 +132,7 @@ export const client = createAuthClient<Profile>()
 
 ```typescript
 // auth.ts
-export const client = createAuthClient()
+export const client = authCreateClient()
 
 // app.tsx
 client.onChange((state) => {
@@ -155,7 +155,7 @@ For SSR, pass a custom `fetch` that forwards cookies from the incoming
 request:
 
 ```typescript
-const ssrClient = createAuthClient({
+const ssrClient = authCreateClient({
   baseUrl: 'http://localhost:3000/auth',
   fetch: async (url, init) => {
     return fetch(url, {
@@ -169,5 +169,5 @@ const initialState = await ssrClient.getSession()
 ```
 
 The initial state ships down to the client in the HTML, and the
-client-side `createAuthClient` rehydrates from it without an extra
+client-side `authCreateClient` rehydrates from it without an extra
 round trip.

--- a/apps/duck/content/docs/duck-auth/client/vue.mdx
+++ b/apps/duck/content/docs/duck-auth/client/vue.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vue client
-description: Vue 3 composables - useSession, useSignIn, useSignOut. Reactive across components and across browser tabs.
+description: Vue 3 composables - authUseSession, authUseSignIn, authUseSignOut. Reactive across components and across browser tabs.
 section: Client
 ---
 
@@ -18,13 +18,13 @@ const auth = createAuth({
 createApp(App).use(auth).mount('#app')
 ```
 
-## `useSession`
+## `authUseSession`
 
 ```vue
 <script setup lang="ts">
-import { useSession } from '@gentleduck/auth/client/vue'
+import { authUseSession } from '@gentleduck/auth/client/vue'
 
-const { data, status } = useSession()
+const { data, status } = authUseSession()
 </script>
 
 <template>
@@ -39,18 +39,18 @@ const { data, status } = useSession()
 </template>
 ```
 
-`useSession()` returns a `Ref` (under the hood, it's a composable
+`authUseSession()` returns a `Ref` (under the hood, it's a composable
 backed by `ref()` + the vanilla client's `onChange` subscription).
 Use it in `<template>` directly.
 
-## `useSignIn` / `useSignOut`
+## `authUseSignIn` / `authUseSignOut`
 
 ```vue
 <script setup lang="ts">
-import { useSignIn, useSignOut } from '@gentleduck/auth/client/vue'
+import { authUseSignIn, authUseSignOut } from '@gentleduck/auth/client/vue'
 
-const signIn = useSignIn()
-const signOut = useSignOut()
+const signIn = authUseSignIn()
+const signOut = authUseSignOut()
 
 const email = ref('')
 const password = ref('')
@@ -115,7 +115,7 @@ createAuth({
 
 ```vue
 <script setup>
-const signIn = useSignIn()
+const signIn = authUseSignIn()
 </script>
 
 <template>

--- a/apps/duck/content/docs/duck-auth/comparison.mdx
+++ b/apps/duck/content/docs/duck-auth/comparison.mdx
@@ -34,7 +34,7 @@ hosted plane.
 | **Multi-tenant orgs** | Yes (built-in `orgs` facet) | No | Yes | DIY | DIY |
 | **Compliance presets** | GDPR / SOC2 / HIPAA / FIPS | None | SOC2 (managed) | None | None |
 | **`strict()` boot gate** | Yes | No | N/A (hosted) | No | No |
-| **Audit log** | Built-in event bus + `WebhookDeliverer` | None | Built-in | DIY | None |
+| **Audit log** | Built-in event bus + `AuthWebhookDeliverer` | None | Built-in | DIY | None |
 | **OpenAPI spec** | Generated from runtime | No | Yes | No | No |
 | **OpenTelemetry** | Built-in (`@gentleduck/auth/telemetry/otel`) | None | None | None | None |
 | **CLI** | `init` / `doctor` / `keys` / `migrate` / `emit-openapi` | None | Limited | None | None |

--- a/apps/duck/content/docs/duck-auth/concepts.mdx
+++ b/apps/duck/content/docs/duck-auth/concepts.mdx
@@ -198,14 +198,14 @@ See [Compliance presets ->](/duck-auth/core/compliance).
 ### `dataAtRest`
 
 Field-level encryption for sensitive credentials and profile data.
-duck-auth ships `AesGcmDataAtRest` (local key) and
-`KmsEnvelopeDataAtRest` (AWS KMS or your own KMS).
+duck-auth ships `AuthAesGcmDataAtRest` (local key) and
+`AuthKmsEnvelopeDataAtRest` (AWS KMS or your own KMS).
 
 ### `strict()`
 
 The boot-time validator. Called as `auth.strict({ env: 'production' })`,
 it rejects insecure configuration (`IamMemoryAdapter` in production,
-`NoopLimiter`, `secure: false` cookies, etc.) before the first
+`AuthNoopLimiter`, `secure: false` cookies, etc.) before the first
 request.
 
 See [Production hardening ->](/duck-auth/advanced/security).

--- a/apps/duck/content/docs/duck-auth/core/anomaly.mdx
+++ b/apps/duck/content/docs/duck-auth/core/anomaly.mdx
@@ -31,12 +31,12 @@ if (ctx?.anomaly?.decision === 'deny') {
 
 ## Shipped detectors
 
-### `impossibleTravelDetector`
+### `authImpossibleTravelDetector`
 
 ```typescript
-import { impossibleTravelDetector } from '@gentleduck/auth/core'
+import { authImpossibleTravelDetector } from '@gentleduck/auth/core'
 
-auth.anomaly.register(impossibleTravelDetector({
+auth.anomaly.register(authImpossibleTravelDetector({
   maxSpeedKmh: 900,          // default - jet speed
   scoreOnViolation: 100,     // default - maximum
   geoipProvider: async (ip) => {

--- a/apps/duck/content/docs/duck-auth/core/compliance.mdx
+++ b/apps/duck/content/docs/duck-auth/core/compliance.mdx
@@ -11,7 +11,7 @@ configuration overrides for the named regulatory scope:
 
 - Replace `ScryptHasher` with `Argon2idHasher` (HIPAA / FIPS).
 - Force `dataAtRest` encryption on identities and credentials.
-- Register `impossibleTravelDetector` + `deviceFingerprintDetector`.
+- Register `authImpossibleTravelDetector` + `deviceFingerprintDetector`.
 - Tighten password policy (minLength 14+).
 - Set `anomaly.onDetectorError` to `step-up` (SOC2) or `deny` (FIPS).
 - Cap `session.absoluteTtlMs` (HIPAA: 30 days; FIPS: 7 days).
@@ -27,7 +27,7 @@ import { hipaa } from '@gentleduck/auth/core'
 const config = hipaa({
   stores: { /* ... */ },
   events: new AuthRedisEvents(redis),
-  channels: { email: new SesChannel({ ... }) },
+  channels: { email: new AuthSesChannel({ ... }) },
 })
 
 export const auth = new AuthEngine({
@@ -36,7 +36,7 @@ export const auth = new AuthEngine({
 })
 ```
 
-Presets return an `AuthEngine.IConfig` shape that you spread into
+Presets return an `AuthEngineTypes.IConfig` shape that you spread into
 `new AuthEngine({ ... })`. Add your own keys after to override.
 
 ## Available presets
@@ -76,7 +76,7 @@ rather than stacking.
 ### `soc2`
 
 - All `gdpr` requirements.
-- `impossibleTravelDetector` + `deviceFingerprintDetector` registered.
+- `authImpossibleTravelDetector` + `deviceFingerprintDetector` registered.
 - `anomaly.onDetectorError: 'step-up'`.
 - `WebhookDeliverer` wired to ship every audit event to an external sink.
 - `session.absoluteTtlMs: 30 days` cap.
@@ -85,9 +85,9 @@ rather than stacking.
 ### `hipaa`
 
 - All `soc2` requirements.
-- `passwords.hasher: Argon2idHasher(ARGON2ID_COMPLIANCE)`.
+- `passwords.hasher: Argon2idHasher(AUTH_ARGON2ID_COMPLIANCE)`.
 - `passwords.minLength: 14`.
-- `dataAtRest: AesGcmDataAtRest` with a `KeyProvider` (you supply).
+- `dataAtRest: AuthAesGcmDataAtRest` with a `KeyProvider` (you supply).
 - `channel` must implement an audit hook (HIPAA logs every message).
 - `session.absoluteTtlMs: 30 days` cap (already set by SOC2 layer).
 - `mfa.enforced: true` - at least one MFA factor required per identity.
@@ -95,9 +95,9 @@ rather than stacking.
 ### `fips`
 
 - All `hipaa` requirements.
-- `passwords.hasher: Argon2idHasher(ARGON2ID_COMPLIANCE)`.
+- `passwords.hasher: Argon2idHasher(AUTH_ARGON2ID_COMPLIANCE)`.
 - `JwtTransport.algorithms`: `ES256` / `EdDSA` only. HS256 / RS256 rejected.
-- `dataAtRest: KmsEnvelopeDataAtRest` - local key material disallowed.
+- `dataAtRest: AuthKmsEnvelopeDataAtRest` - local key material disallowed.
 - `anomaly.onDetectorError: 'deny'`.
 - `session.absoluteTtlMs: 7 days` cap.
 - `passwords.minLength: 16`.

--- a/apps/duck/content/docs/duck-auth/core/compliance.mdx
+++ b/apps/duck/content/docs/duck-auth/core/compliance.mdx
@@ -9,7 +9,7 @@ section: Core
 duck-auth ships four compliance presets that wire a coherent set of
 configuration overrides for the named regulatory scope:
 
-- Replace `ScryptHasher` with `Argon2idHasher` (HIPAA / FIPS).
+- Replace `AuthScryptHasher` with `AuthArgon2idHasher` (HIPAA / FIPS).
 - Force `dataAtRest` encryption on identities and credentials.
 - Register `authImpossibleTravelDetector` + `deviceFingerprintDetector`.
 - Tighten password policy (minLength 14+).
@@ -22,13 +22,18 @@ configuration overrides for the named regulatory scope:
 Apply one preset to a `stores` / `events` / `channels` triple:
 
 ```typescript
-import { hipaa } from '@gentleduck/auth/core'
+import { authApplyCompliancePreset } from '@gentleduck/auth/core'
 
-const config = hipaa({
-  stores: { /* ... */ },
-  events: new AuthRedisEvents(redis),
-  channels: { email: new AuthSesChannel({ ... }) },
-})
+const config = authApplyCompliancePreset(
+  {
+    baseUrl: process.env.APP_URL!,
+    stores: { /* ... */ },
+    events: new AuthRedisEvents(redis),
+    channels: { email: new AuthSesChannel({ ... }) },
+    transport: new AuthCookieTransport({ name: 'duck-sid', secure: true }),
+  },
+  'hipaa',
+)
 
 export const auth = new AuthEngine({
   ...config,
@@ -36,8 +41,8 @@ export const auth = new AuthEngine({
 })
 ```
 
-Presets return an `AuthEngineTypes.IConfig` shape that you spread into
-`new AuthEngine({ ... })`. Add your own keys after to override.
+`authApplyCompliancePreset(base, preset)` returns an `AuthEngineTypes.IConfig` shape.
+Add your own keys after to override.
 
 ## Available presets
 
@@ -53,10 +58,13 @@ Presets return an `AuthEngineTypes.IConfig` shape that you spread into
 You can layer presets - the last one is dominant where they conflict:
 
 ```typescript
-import { gdpr, hipaa } from '@gentleduck/auth/core'
+import { authApplyCompliancePreset } from '@gentleduck/auth/core'
 
-const layered = { ...gdpr({ ... }), ...hipaa({ ... }) }
-// HIPAA wins on overlapping keys (Argon2 vs scrypt)
+// Apply both — HIPAA wins on overlapping keys (Argon2 vs scrypt)
+const layered = authApplyCompliancePreset(
+  authApplyCompliancePreset(base, 'gdpr'),
+  'hipaa',
+)
 ```
 
 For ergonomic clarity, prefer applying the strictest preset directly
@@ -78,14 +86,14 @@ rather than stacking.
 - All `gdpr` requirements.
 - `authImpossibleTravelDetector` + `deviceFingerprintDetector` registered.
 - `anomaly.onDetectorError: 'step-up'`.
-- `WebhookDeliverer` wired to ship every audit event to an external sink.
+- `AuthWebhookDeliverer` wired to ship every audit event to an external sink.
 - `session.absoluteTtlMs: 30 days` cap.
 - `OtelInstrumentation` recommended (a warning fires at boot if absent).
 
 ### `hipaa`
 
 - All `soc2` requirements.
-- `passwords.hasher: Argon2idHasher(AUTH_ARGON2ID_COMPLIANCE)`.
+- `passwords.hasher: AuthArgon2idHasher(ARGON2ID_COMPLIANCE)`.
 - `passwords.minLength: 14`.
 - `dataAtRest: AuthAesGcmDataAtRest` with a `KeyProvider` (you supply).
 - `channel` must implement an audit hook (HIPAA logs every message).
@@ -95,7 +103,7 @@ rather than stacking.
 ### `fips`
 
 - All `hipaa` requirements.
-- `passwords.hasher: Argon2idHasher(AUTH_ARGON2ID_COMPLIANCE)`.
+- `passwords.hasher: AuthArgon2idHasher(ARGON2ID_COMPLIANCE)`.
 - `JwtTransport.algorithms`: `ES256` / `EdDSA` only. HS256 / RS256 rejected.
 - `dataAtRest: AuthKmsEnvelopeDataAtRest` - local key material disallowed.
 - `anomaly.onDetectorError: 'deny'`.
@@ -109,9 +117,9 @@ rather than stacking.
 ```typescript
 new AuthEngine({
   ...hipaa({ ... }),
-  passwords: { hasher: new ScryptHasher() },  // <- overrides Argon2 - strict() will fail
+  passwords: { hasher: new AuthScryptHasher() },  // <- overrides Argon2 - strict() will fail
 })
-// throws AUTH/MISCONFIGURED: { gate: 'compliance', preset: 'hipaa', expected: 'Argon2idHasher' }
+// throws AUTH/MISCONFIGURED: { gate: 'compliance', preset: 'hipaa', expected: 'AuthArgon2idHasher' }
 ```
 
 The preset is the source of truth; manual overrides that violate it are

--- a/apps/duck/content/docs/duck-auth/core/compliance/index.mdx
+++ b/apps/duck/content/docs/duck-auth/core/compliance/index.mdx
@@ -38,12 +38,12 @@ for (const event of SENSITIVE) {
 ## Encryption at rest
 
 Profile data (`AuthIdentity.IIdentity.profile`) is the most-likely place to
-store PII. Wrap the identities store with `AesGcmDataAtRest`:
+store PII. Wrap the identities store with `AuthAesGcmDataAtRest`:
 
 ```typescript
-import { AesGcmDataAtRest } from '@gentleduck/auth/core/dataAtRest'
+import { AuthAesGcmDataAtRest } from '@gentleduck/auth/core/dataAtRest'
 
-const wrapped = AesGcmDataAtRest.wrapIdentitiesStore(
+const wrapped = AuthAesGcmDataAtRest.wrapIdentitiesStore(
   adapter.identities,
   { keyset: process.env.PII_KEYSET },
 )

--- a/apps/duck/content/docs/duck-auth/core/data-at-rest.mdx
+++ b/apps/duck/content/docs/duck-auth/core/data-at-rest.mdx
@@ -10,7 +10,7 @@ land in the database in plaintext. Both are wire-compatible: the same
 record can be re-encrypted under a different adapter without a
 migration as long as the ciphertext format markers stay distinct.
 
-## `AesGcmDataAtRest`
+## `AuthAesGcmDataAtRest`
 
 Local-key AES-256-GCM with deterministic per-record DEK derivation
 (`DEK = sha256(masterKey || identityId || field)`). Every encrypt
@@ -18,9 +18,9 @@ samples a fresh 12-byte IV, so the GCM birthday bound is ~2^48
 encryptions per (identity, field) pair.
 
 ```typescript
-import { AesGcmDataAtRest } from '@gentleduck/auth/core/dataAtRest'
+import { AuthAesGcmDataAtRest } from '@gentleduck/auth/core/dataAtRest'
 
-const dataAtRest = new AesGcmDataAtRest({
+const dataAtRest = new AuthAesGcmDataAtRest({
   kid: 'k1',
   masterKey: Buffer.from(process.env.DUCK_AUTH_MASTER_KEY_K1!, 'base64'),
   previousKeys: [
@@ -39,7 +39,7 @@ Each `encrypt()` rejects plaintexts longer than 1 MiB to prevent a
 hostile caller driving multi-GB encrypt cycles + base64 expansion via
 this surface.
 
-## `KmsEnvelopeDataAtRest`
+## `AuthKmsEnvelopeDataAtRest`
 
 Envelope encryption against any `Kms.IProvider`. A fresh per-record
 DEK is requested from the KMS, the plaintext is encrypted locally
@@ -48,11 +48,11 @@ stored together. `decrypt` unwraps the DEK via the KMS and runs the
 AES-GCM inverse locally.
 
 ```typescript
-import { KmsEnvelopeDataAtRest } from '@gentleduck/auth/core/dataAtRest'
-import { AwsKmsProvider } from '@gentleduck/auth/core/dataAtRest'
+import { AuthKmsEnvelopeDataAtRest } from '@gentleduck/auth/core/dataAtRest'
+import { AuthAwsKmsProvider } from '@gentleduck/auth/core/dataAtRest'
 
-const dataAtRest = new KmsEnvelopeDataAtRest({
-  kms: new AwsKmsProvider({
+const dataAtRest = new AuthKmsEnvelopeDataAtRest({
+  kms: new AuthAwsKmsProvider({
     keyId: 'alias/duck-auth-data-at-rest',
     client: new KmsClient({ region: 'us-east-1' }),
   }),
@@ -75,7 +75,7 @@ field}`, so the KMS itself enforces that a wrapped DEK can only be
 unwrapped for the same record it was generated for. This is the **AAD
 pin** that protects against ciphertext relocation attacks across rows.
 
-## `AwsKmsProvider`
+## `AuthAwsKmsProvider`
 
 Reference `Kms.IProvider` for AWS KMS. Lazy-loads `@aws-sdk/client-kms`
 so the AWS SDK stays an OPTIONAL peerDep - the rest of duck-auth never
@@ -83,9 +83,9 @@ pulls it in.
 
 ```typescript
 import { KmsClient } from '@aws-sdk/client-kms'
-import { AwsKmsProvider } from '@gentleduck/auth/core/dataAtRest'
+import { AuthAwsKmsProvider } from '@gentleduck/auth/core/dataAtRest'
 
-const provider = new AwsKmsProvider({
+const provider = new AuthAwsKmsProvider({
   keyId: 'alias/duck-auth-data-at-rest',
   client: new KmsClient({ region: 'us-east-1' }),
 })
@@ -111,7 +111,7 @@ class GcpKmsProvider implements Kms.IProvider {
 }
 ```
 
-Wrap it in `KmsEnvelopeDataAtRest` and ship. The same recipe works for
+Wrap it in `AuthKmsEnvelopeDataAtRest` and ship. The same recipe works for
 Vault Transit, Azure Key Vault, or in-house HSMs.
 
 ## Compliance presets

--- a/apps/duck/content/docs/duck-auth/core/errors.mdx
+++ b/apps/duck/content/docs/duck-auth/core/errors.mdx
@@ -121,7 +121,7 @@ throw new AuthError('AUTH/INVALID_CREDENTIALS', {
 
 | Code | Status | Meaning |
 | --- | --- | --- |
-| `AUTH/MISCONFIGURED` | 500 | Raised by `AuthEngine.strict()` when a production gate fails (NoopLimiter, IamMemoryAdapter, etc.). |
+| `AUTH/MISCONFIGURED` | 500 | Raised by `AuthEngine.strict()` when a production gate fails (AuthNoopLimiter, IamMemoryAdapter, etc.). |
 
 ## Wire-safe serialisation
 

--- a/apps/duck/content/docs/duck-auth/core/events.mdx
+++ b/apps/duck/content/docs/duck-auth/core/events.mdx
@@ -1,6 +1,6 @@
 ---
 title: Events
-description: InMemoryEvents, AuthRedisEvents, the typed event taxonomy, and WebhookDeliverer for signed outbound delivery.
+description: AuthInMemoryEvents, AuthRedisEvents, the typed event taxonomy, and AuthWebhookDeliverer for signed outbound delivery.
 section: Core
 ---
 
@@ -8,14 +8,14 @@ section: Core
 
 duck-auth emits every lifecycle event (identity created, session rotated,
 MFA enrolled, anomaly signalled, lockout fired) through a single
-`AuthEvents.IBus`. The default is `InMemoryEvents`; production deployments
+`AuthEvents.IBus`. The default is `AuthInMemoryEvents`; production deployments
 swap to `AuthRedisEvents` for cross-process fan-out.
 
 ```typescript
-import { InMemoryEvents } from '@gentleduck/auth/core'
+import { AuthInMemoryEvents } from '@gentleduck/auth/core'
 
 export const auth = new AuthEngine({
-  events: new InMemoryEvents(),
+  events: new AuthInMemoryEvents(),
 })
 
 const unsubscribe = auth.events.on('session.rotated', (event) => {
@@ -102,15 +102,15 @@ The `lockout` event is the one `strict()` will complain about if no
 listener is attached in production - at minimum, you should be paging on
 or auditing every lockout.
 
-## WebhookDeliverer
+## AuthWebhookDeliverer
 
 For outbound integrations (audit log SaaS, CRM, downstream services),
 ship every event over signed HTTPS:
 
 ```typescript
-import { WebhookDeliverer } from '@gentleduck/auth/core'
+import { AuthWebhookDeliverer } from '@gentleduck/auth/core'
 
-const deliverer = new WebhookDeliverer({
+const deliverer = new AuthWebhookDeliverer({
   url: 'https://example.com/auth-events',
   secret: process.env.WEBHOOK_SECRET!,
 })
@@ -124,11 +124,11 @@ The body is HMAC-SHA256 signed; the signature rides on an
 `X-Duck-Auth-Signature` header. On the receiving side:
 
 ```typescript
-import { verifyWebhookSignature } from '@gentleduck/auth/core'
+import { authVerifyWebhookSignature } from '@gentleduck/auth/core'
 
 const raw = await req.text()
 const sig = req.headers.get('x-duck-auth-signature')!
-const ok = verifyWebhookSignature(raw, sig, process.env.WEBHOOK_SECRET!)
+const ok = authVerifyWebhookSignature(raw, sig, process.env.WEBHOOK_SECRET!)
 if (!ok) return new Response('bad signature', { status: 401 })
 ```
 

--- a/apps/duck/content/docs/duck-auth/core/index.mdx
+++ b/apps/duck/content/docs/duck-auth/core/index.mdx
@@ -41,7 +41,7 @@ hidden global, no module-level state, no implicit singleton.
 ## Constructor at a glance
 
 ```typescript
-import { AuthEngine, InMemoryEvents, ScryptHasher } from '@gentleduck/auth/core'
+import { AuthEngine, AuthInMemoryEvents, AuthScryptHasher } from '@gentleduck/auth/core'
 import { CookieTransport } from '@gentleduck/auth/core/transport'
 import { AuthMemoryAdapter } from '@gentleduck/auth/adapters/memory'
 import { AuthMemoryLimiter } from '@gentleduck/auth/limiters/memory'
@@ -57,9 +57,9 @@ export const auth = new AuthEngine({
     credentials: adapter.credentials,
     // orgs is optional - pass adapter.orgs to enable the orgs facet
   },
-  events: new InMemoryEvents(),
+  events: new AuthInMemoryEvents(),
   limiter: new AuthMemoryLimiter({ max: 5, windowMs: 60_000 }),
-  passwords: { hasher: new ScryptHasher() },
+  passwords: { hasher: new AuthScryptHasher() },
 })
 ```
 
@@ -68,12 +68,12 @@ export const auth = new AuthEngine({
 | `baseUrl` | Issuer for JWTs, OIDC discovery, signed redirect callbacks. |
 | `transport` | The session carrier (`CookieTransport` / `BearerTransport` / `JwtTransport` / `CompositeTransport`). |
 | `stores` | `identities`, `sessions`, `credentials`, optionally `orgs`. Implements the per-table store interfaces. |
-| `limiter` | Rate-limiter. Use `AuthMemoryLimiter` in dev; Redis-backed in production. `strict()` rejects `NoopLimiter` in production. |
+| `limiter` | Rate-limiter. Use `AuthMemoryLimiter` in dev; Redis-backed in production. `strict()` rejects `AuthNoopLimiter` in production. |
 | `session` | Per-session TTLs: `ttlMs` (default 7d), `absoluteTtlMs` (default 30d), `freshnessMs` (default 5m). |
 | `identities` | `softDeleteGracePeriodMs` (default 7d), `profileMaxBytes` (default 16 KiB). |
 | `passwords` | `hasher` plus optional `minLength` / `maxLength` / `rejectCommon`. |
 | `providers` | Array of `AuthProvider.IProvider` instances to register at boot. |
-| `events` | `AuthEvents.IBus`. Default is `InMemoryEvents` - swap to `AuthRedisEvents` or a custom bus for fan-out. |
+| `events` | `AuthEvents.IBus`. Default is `AuthInMemoryEvents` - swap to `AuthRedisEvents` or a custom bus for fan-out. |
 | `mfa` | `issuer`, `backupCodeCount`, `backupCodeLen`. |
 | `apiKeys` | `prefix` (e.g. `ak_live_`), `randomBytes`. |
 | `hijack` | Detection sensitivity + reaction (`ignore`/`rotate`/`mfa`/`revoke`). |
@@ -151,9 +151,9 @@ The generics propagate everywhere: `auth.identities.findById(id)` returns
 
 - [Sessions ->](/duck-auth/core/sessions) - the 7-row rotation matrix.
 - [Identities ->](/duck-auth/core/identities) - CRUD, linking, GDPR.
-- [Passwords ->](/duck-auth/core/passwords) - `ScryptHasher`, `Argon2idHasher`.
+- [Passwords ->](/duck-auth/core/passwords) - `AuthScryptHasher`, `AuthArgon2idHasher`.
 - [Transports ->](/duck-auth/core/transports) - Cookie, Bearer, JWT, Composite, DPoP.
-- [Events ->](/duck-auth/core/events) - `InMemoryEvents`, `AuthRedisEvents`, `WebhookDeliverer`.
+- [Events ->](/duck-auth/core/events) - `AuthInMemoryEvents`, `AuthRedisEvents`, `AuthWebhookDeliverer`.
 - [Anomaly ->](/duck-auth/core/anomaly) - detectors and the step-up decision.
 - [Compliance ->](/duck-auth/core/compliance) - `gdpr`, `hipaa`, `soc2`, `fips`.
 - [Errors ->](/duck-auth/core/errors) - every `AUTH/*` code and its status.

--- a/apps/duck/content/docs/duck-auth/core/passwords.mdx
+++ b/apps/duck/content/docs/duck-auth/core/passwords.mdx
@@ -1,6 +1,6 @@
 ---
 title: Passwords
-description: ScryptHasher (built-in) and Argon2idHasher (lazy peerDep). Hash, verify, and rehash on successful sign-in.
+description: AuthScryptHasher (built-in) and AuthArgon2idHasher (lazy peerDep). Hash, verify, and rehash on successful sign-in.
 section: Core
 ---
 
@@ -20,12 +20,12 @@ to call them yourself unless you are building a custom flow.
 
 ## Built-in hashers
 
-### `ScryptHasher` - zero dependencies
+### `AuthScryptHasher` - zero dependencies
 
 ```typescript
-import { ScryptHasher } from '@gentleduck/auth/core'
+import { AuthScryptHasher } from '@gentleduck/auth/core'
 
-const hasher = new ScryptHasher({
+const hasher = new AuthScryptHasher({
   N: 2 ** 17,    // CPU/memory cost - default
   r: 8,
   p: 1,
@@ -37,12 +37,12 @@ const hasher = new ScryptHasher({
 Uses Node's built-in `crypto.scrypt`. **Zero peer dependencies**.
 Default for v0.1. Format: `scrypt$N$r$p$<salt-b64>$<key-b64>`.
 
-### `Argon2idHasher` - required for HIPAA / FIPS
+### `AuthArgon2idHasher` - required for HIPAA / FIPS
 
 ```typescript
-import { Argon2idHasher } from '@gentleduck/auth/core'
+import { AuthArgon2idHasher } from '@gentleduck/auth/core'
 
-const hasher = new Argon2idHasher({
+const hasher = new AuthArgon2idHasher({
   memoryCost: 19456,   // OWASP minimum
   timeCost: 2,
   parallelism: 1,
@@ -59,8 +59,8 @@ Two parameter presets are exported:
 ```typescript
 import { ARGON2ID_DEFAULTS, ARGON2ID_COMPLIANCE } from '@gentleduck/auth/core'
 
-new Argon2idHasher(ARGON2ID_DEFAULTS)     // OWASP minimum
-new Argon2idHasher(ARGON2ID_COMPLIANCE)   // HIPAA / FIPS preset
+new AuthArgon2idHasher(ARGON2ID_DEFAULTS)     // OWASP minimum
+new AuthArgon2idHasher(ARGON2ID_COMPLIANCE)   // HIPAA / FIPS preset
 ```
 
 ## Rehash on sign-in
@@ -88,7 +88,7 @@ and silently updates the row. No downtime, no migration script.
 ```typescript
 new AuthEngine({
   passwords: {
-    hasher: new ScryptHasher(),
+    hasher: new AuthScryptHasher(),
     minLength: 12,           // default 8
     maxLength: 1024,         // default 1024
     rejectCommon: true,      // bundled top-10k list

--- a/apps/duck/content/docs/duck-auth/core/transports/bearer.mdx
+++ b/apps/duck/content/docs/duck-auth/core/transports/bearer.mdx
@@ -59,9 +59,9 @@ The client persists the token. Subsequent requests carry it on the
 ## Sign-out
 
 ```typescript
-import { mountSignOut } from '@gentleduck/auth/server/express'
+import { authMountSignOut } from '@gentleduck/auth/server/express'
 
-app.post('/auth/signout', mountSignOut(auth))
+app.post('/auth/signout', authMountSignOut(auth))
 ```
 
 The handler reads the `Authorization` header, revokes the session row,

--- a/apps/duck/content/docs/duck-auth/core/transports/composite.mdx
+++ b/apps/duck/content/docs/duck-auth/core/transports/composite.mdx
@@ -99,8 +99,8 @@ from the web app - same handler, same `auth.resolveSession()` call.
 
 ## Caveat: CSRF only on cookie path
 
-`csrfGuard()` only runs CSRF checks if the resolved session came in via
+`authCsrfGuard()` only runs CSRF checks if the resolved session came in via
 a cookie. Bearer/JWT routes are exempt (no cookies, no CSRF) - but the
-mixed router still needs to call `csrfGuard()` defensively. The guard
+mixed router still needs to call `authCsrfGuard()` defensively. The guard
 reads the transport hint and silently passes through for non-cookie
 sessions.

--- a/apps/duck/content/docs/duck-auth/core/transports/cookie.mdx
+++ b/apps/duck/content/docs/duck-auth/core/transports/cookie.mdx
@@ -14,7 +14,7 @@ defence-in-depth bit out of the box:
 - `HttpOnly` (JavaScript cannot read or modify the cookie).
 - `SameSite=Lax` (no cross-site POST gives the cookie up).
 - Constant-time session lookup with a hashed-at-rest session id.
-- Double-submit CSRF defence wired through `csrfGuard`.
+- Double-submit CSRF defence wired through `authCsrfGuard`.
 
 ## Constructor
 
@@ -52,16 +52,16 @@ id - even a database leak does not yield usable session tokens.
 ## CSRF defence
 
 Cookies ride along on cross-site POST/PUT/DELETE, so every state-mutating
-endpoint must call `csrfGuard`:
+endpoint must call `authCsrfGuard`:
 
 ```typescript
-import { csrfGuard, issueCsrfToken } from '@gentleduck/auth/core'
+import { authCsrfGuard, authIssueCsrfToken } from '@gentleduck/auth/core'
 
 // Issue: on session start, set a non-HttpOnly companion cookie.
 const intents = await auth.flows.signIn({ providerId: 'password', input })
 intents.push({ kind: 'setCookie', cookie: {
   name: '__Host-duck-csrf',
-  value: issueCsrfToken(),
+  value: authIssueCsrfToken(),
   path: '/',
   secure: true,
   sameSite: 'lax',
@@ -69,12 +69,12 @@ intents.push({ kind: 'setCookie', cookie: {
 }})
 
 // Verify: on every state-mutating request.
-await csrfGuard(auth, req)  // throws AUTH/CSRF on mismatch
+await authCsrfGuard(auth, req)  // throws AUTH/CSRF on mismatch
 ```
 
 The CSRF token is double-submit: the client reads `__Host-duck-csrf`
 from the cookie and echoes it back as `X-CSRF-Token` on every mutating
-request. `csrfGuard` constant-time-compares them.
+request. `authCsrfGuard` constant-time-compares them.
 
 GET/HEAD/OPTIONS are exempt, as are Bearer/JWT routes (no cookies, no
 CSRF).
@@ -82,9 +82,9 @@ CSRF).
 ## Sign-out
 
 ```typescript
-import { mountSignOut } from '@gentleduck/auth/server/express'
+import { authMountSignOut } from '@gentleduck/auth/server/express'
 
-app.post('/auth/signout', mountSignOut(auth))
+app.post('/auth/signout', authMountSignOut(auth))
 ```
 
 The transport emits a `Set-Cookie` with `Max-Age=0` to clear the cookie

--- a/apps/duck/content/docs/duck-auth/core/transports/dpop.mdx
+++ b/apps/duck/content/docs/duck-auth/core/transports/dpop.mdx
@@ -29,7 +29,7 @@ thing to mTLS for browser SPAs and mobile apps.
 
 ```typescript
 import {
-  computeJwkThumbprint,
+  authComputeJwkThumbprint,
   DPoPVerifier,
   MemoryDPoPNonceStore,
 } from '@gentleduck/auth/core/transport'
@@ -88,7 +88,7 @@ For internal services that mint short-lived JWTs and want to bind them
 to the DPoP key:
 
 ```typescript
-import { bindPayloadToDPoP } from '@gentleduck/auth/core/transport'
+import { authBindPayloadToDPoP } from '@gentleduck/auth/core/transport'
 
 const payload = {
   sub: 'identity-id',
@@ -96,7 +96,7 @@ const payload = {
   exp: Math.floor(Date.now() / 1000) + 60,
 }
 
-const bound = bindPayloadToDPoP(payload, dpopHeader)
+const bound = authBindPayloadToDPoP(payload, dpopHeader)
 // bound = { ...payload, cnf: { jkt: '<thumbprint>' } }
 
 const jwt = await transport.signJwt(bound)
@@ -111,9 +111,9 @@ along with the token.
 For custom flows that need to compute the RFC 7638 thumbprint of a JWK:
 
 ```typescript
-import { computeJwkThumbprint } from '@gentleduck/auth/core/transport'
+import { authComputeJwkThumbprint } from '@gentleduck/auth/core/transport'
 
-const jkt = await computeJwkThumbprint(clientJwk)
+const jkt = await authComputeJwkThumbprint(clientJwk)
 // -> 'kIQ-AzaP-...' (43-character base64url)
 ```
 

--- a/apps/duck/content/docs/duck-auth/faq.mdx
+++ b/apps/duck/content/docs/duck-auth/faq.mdx
@@ -86,10 +86,10 @@ See [Writing a custom provider ->](/duck-auth/providers#writing-a-custom-provide
 
 ## Can I have my own adapter?
 
-Yes. Implement `SqlBridge.IBridge` and pass it to `createSqlAuthStores`:
+Yes. Implement `SqlBridge.IBridge` and pass it to `authCreateSqlStores`:
 
 ```typescript
-const stores = createSqlAuthStores({ bridge: myBridge })
+const stores = authCreateSqlStores({ bridge: myBridge })
 ```
 
 Or implement the four store interfaces directly. Run the [compliance
@@ -101,7 +101,7 @@ implementation.
 Yes, with caveats:
 
 - **Vercel Edge / Cloudflare Workers**: use `JwtTransport` (no DB
-  hits per request) and `Argon2idHasher` (Node's `crypto.scrypt` isn't
+  hits per request) and `AuthArgon2idHasher` (Node's `crypto.scrypt` isn't
   on Workers).
 - **AWS Lambda**: works as-is. Cold-start cost is ~300ms for the first
   request after a deploy - pin a warmer if that matters.
@@ -111,7 +111,7 @@ Yes, with caveats:
 
 ## How fast is it?
 
-A signin endpoint with `ScryptHasher` defaults is ~30ms per call
+A signin endpoint with `AuthScryptHasher` defaults is ~30ms per call
 (20ms hash + 5ms DB + 5ms cookie issue). With Argon2id at OWASP
 defaults, ~80ms. JWT verify (no DB hit) is <1ms.
 

--- a/apps/duck/content/docs/duck-auth/guides/index.mdx
+++ b/apps/duck/content/docs/duck-auth/guides/index.mdx
@@ -37,20 +37,20 @@ psql $DATABASE_URL < drizzle/0001_auth.sql
 ```typescript title="src/lib/auth.ts"
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { Pool } from 'pg'
-import { Argon2idHasher, AuthEngine } from '@gentleduck/auth/core'
+import { AuthArgon2idHasher, AuthEngine } from '@gentleduck/auth/core'
 import { CookieTransport } from '@gentleduck/auth/core/transport'
 import { createDrizzlePgBridge } from '@gentleduck/auth/adapters/drizzle/pg'
-import { createSqlAuthStores } from '@gentleduck/auth/adapters/sql'
+import { authCreateSqlStores } from '@gentleduck/auth/adapters/sql'
 import { AuthMemoryLimiter } from '@gentleduck/auth/limiters/memory'
 import { magicLink } from '@gentleduck/auth/providers/magic-link'
 import { password } from '@gentleduck/auth/providers/password'
-import { ResendChannel } from '@gentleduck/auth/channels/resend'
+import { AuthResendChannel } from '@gentleduck/auth/channels/resend'
 import { schema } from './db/schema'
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL })
 const db = drizzle(pool)
 const bridge = createDrizzlePgBridge(db, schema)
-const sql = createSqlAuthStores({ bridge })
+const sql = authCreateSqlStores({ bridge })
 
 export const auth = new AuthEngine({
   baseUrl: 'http://localhost:3000',
@@ -61,7 +61,7 @@ export const auth = new AuthEngine({
     sessions: sql.sessions,
   },
   limiter: new AuthMemoryLimiter({ max: 5, windowMs: 60_000 }),
-  passwords: { hasher: new Argon2idHasher() },
+  passwords: { hasher: new AuthArgon2idHasher() },
 })
 
 auth.providers.use(
@@ -74,7 +74,7 @@ auth.providers.use(
 auth.providers.use(
   magicLink({
     channels: {
-      email: new ResendChannel({
+      email: new AuthResendChannel({
         apiKey: process.env.RESEND_API_KEY!,
         from: 'no-reply@example.com',
       }),
@@ -95,21 +95,21 @@ auth.strict({ env: process.env.NODE_ENV === 'production' ? 'production' : 'devel
 import express from 'express'
 import { AuthError } from '@gentleduck/auth/core'
 import {
-  mountProviderBegin,
-  mountSession,
-  mountSignIn,
-  mountSignOut,
+  authMountProviderBegin,
+  authMountSession,
+  authMountSignIn,
+  authMountSignOut,
 } from '@gentleduck/auth/server/express'
 import { auth } from './lib/auth'
 
 const app = express()
 app.use(express.json())
 
-app.post('/auth/signin', mountSignIn(auth))
-app.post('/auth/signout', mountSignOut(auth))
-app.get('/auth/session', mountSession(auth))
+app.post('/auth/signin', authMountSignIn(auth))
+app.post('/auth/signout', authMountSignOut(auth))
+app.get('/auth/session', authMountSession(auth))
 app.post('/auth/providers/:providerId/begin', (req, res, next) =>
-  mountProviderBegin(auth, req.params.providerId)(req, res, next),
+  authMountProviderBegin(auth, req.params.providerId)(req, res, next),
 )
 
 app.get('/api/me', async (req, res, next) => {
@@ -136,7 +136,7 @@ app.listen(3000)
 <Step>Drop in the React client</Step>
 
 ```tsx title="src/App.tsx"
-import { AuthProvider, useSession, useSignIn, useSignOut } from '@gentleduck/auth/client/react'
+import { AuthProvider, authUseSession, authUseSignIn, authUseSignOut } from '@gentleduck/auth/client/react'
 
 export function App() {
   return (
@@ -147,9 +147,9 @@ export function App() {
 }
 
 function Page() {
-  const { data, status } = useSession()
-  const signIn = useSignIn()
-  const signOut = useSignOut()
+  const { data, status } = authUseSession()
+  const signIn = authUseSignIn()
+  const signOut = authUseSignOut()
 
   if (status === 'loading') return <p>Loading...</p>
 
@@ -188,8 +188,8 @@ function Page() {
 - Argon2id hashing.
 - Password + magic-link sign-in.
 - Cookie-based session, HttpOnly, SameSite=Lax.
-- React client with `useSession` / `useSignIn` / `useSignOut`.
-- CSRF guard available via `csrfGuard` (wire it on mutating routes).
+- React client with `authUseSession` / `authUseSignIn` / `authUseSignOut`.
+- CSRF guard available via `authCsrfGuard` (wire it on mutating routes).
 
 ## What's next
 

--- a/apps/duck/content/docs/duck-auth/guides/mfa.mdx
+++ b/apps/duck/content/docs/duck-auth/guides/mfa.mdx
@@ -54,7 +54,7 @@ try {
 }
 ```
 
-The client-side flow is exactly the same shape - the `useSignIn` hook
+The client-side flow is exactly the same shape - the `authUseSignIn` hook
 exposes `error.code` and `error.meta`, and you re-call with the code.
 
 ## Backup codes

--- a/apps/duck/content/docs/duck-auth/installation/index.mdx
+++ b/apps/duck/content/docs/duck-auth/installation/index.mdx
@@ -54,7 +54,7 @@ Install only what you wire:
 <Step>60-second quickstart (Memory adapter)</Step>
 
 ```typescript title="src/lib/auth.ts"
-import { AuthEngine, InMemoryEvents, ScryptHasher } from '@gentleduck/auth/core'
+import { AuthEngine, AuthInMemoryEvents, AuthScryptHasher } from '@gentleduck/auth/core'
 import { CookieTransport } from '@gentleduck/auth/core/transport'
 import { AuthMemoryAdapter } from '@gentleduck/auth/adapters/memory'
 import { AuthMemoryLimiter } from '@gentleduck/auth/limiters/memory'
@@ -69,9 +69,9 @@ export const auth = new AuthEngine({
     sessions: adapter.sessions,
     credentials: adapter.credentials,
   },
-  events: new InMemoryEvents(),
+  events: new AuthInMemoryEvents(),
   limiter: new AuthMemoryLimiter({ max: 5, windowMs: 60_000 }),
-  passwords: { hasher: new ScryptHasher() },
+  passwords: { hasher: new AuthScryptHasher() },
 })
 ```
 
@@ -79,15 +79,15 @@ export const auth = new AuthEngine({
 
 ```typescript title="src/server.ts (Express)"
 import express from 'express'
-import { mountSignIn, mountSignOut, mountSession } from '@gentleduck/auth/server/express'
+import { authMountSignIn, authMountSignOut, authMountSession } from '@gentleduck/auth/server/express'
 import { auth } from './lib/auth'
 
 const app = express()
 app.use(express.json())
 
-app.post('/auth/signin', mountSignIn(auth))
-app.post('/auth/signout', mountSignOut(auth))
-app.get('/auth/session', mountSession(auth))
+app.post('/auth/signin', authMountSignIn(auth))
+app.post('/auth/signout', authMountSignOut(auth))
+app.get('/auth/session', authMountSession(auth))
 
 app.listen(3000)
 ```
@@ -107,7 +107,7 @@ If you prefer a scaffolded starter, the CLI emits a complete `auth.ts`
 plus a `.env` template.
 
 ```bash
-# Quickstart: Memory adapter, ScryptHasher, CookieTransport
+# Quickstart: Memory adapter, AuthScryptHasher, CookieTransport
 bunx @gentleduck/auth init src/lib
 
 # Production: Redis adapter, Argon2id, JwtTransport with rotated keys

--- a/apps/duck/content/docs/duck-auth/introduction.mdx
+++ b/apps/duck/content/docs/duck-auth/introduction.mdx
@@ -46,10 +46,10 @@ router with one adapter import.
 | Provider library | Password, magic-link, six OAuth (Google, GitHub, LinkedIn, Microsoft, Discord, Apple), WebAuthn passkeys (discoverable + username), API keys, SAML. |
 | Storage adapters | Memory (dev/test), Redis (session/idempotency/limiter/events/DPoP nonce), SQL bridge with bundled Drizzle examples for pg / mysql / sqlite. |
 | Channels | Console, SMTP, Resend, AWS SES, Twilio, WebPush, plus Test and Noop. |
-| Strict mode | `AuthEngine.strict({ env: 'production' })` rejects dev-only footguns at boot: insecure cookies, NoopLimiter, IamMemoryAdapter, missing lockout listeners, weak JWT keys, missing compliance presets. |
+| Strict mode | `AuthEngine.strict({ env: 'production' })` rejects dev-only footguns at boot: insecure cookies, AuthNoopLimiter, IamMemoryAdapter, missing lockout listeners, weak JWT keys, missing compliance presets. |
 | Compliance presets | `gdpr`, `hipaa`, `soc2`, `fips` - strictest preset wins. Each enforces hashing, dataAtRest, channel, and anomaly minimums. |
 | Anomaly detection | Impossible-travel and device-fingerprint detectors, plus an aggregator that emits `allow` / `deny` / `step-up`. |
-| Observability | OpenTelemetry instrumentation, `WebhookDeliverer` with HMAC-signed outbound delivery, OpenAPI 3.1 generator, OIDC discovery, JWKS rotation. |
+| Observability | OpenTelemetry instrumentation, `AuthWebhookDeliverer` with HMAC-signed outbound delivery, OpenAPI 3.1 generator, OIDC discovery, JWKS rotation. |
 | CLI | `duck-auth init`, `doctor`, `keys generate`, `keys rotate`, `migrate`, `emit-openapi`. |
 
 ## Architecture
@@ -119,9 +119,9 @@ the architectural rationale lives in [`DESIGN.md`](https://github.com/gentleeduc
 | Clients (vanilla, react, vue, svelte, solid) | shipped |
 | CLI (init / doctor / keys / migrate / emit-openapi) | shipped |
 | OpenAPI generator + OIDC discovery + OpenTelemetry + i18n | shipped |
-| `createTestAuth()` test helper + Storybook decorator | shipped |
+| `authCreateTest()` test helper + Storybook decorator | shipped |
 | WebAuthn-MFA factor | shipped |
-| KMS-envelope DataAtRest (`AwsKmsProvider` reference) | shipped |
+| KMS-envelope DataAtRest (`AuthAwsKmsProvider` reference) | shipped |
 | JwtTransport (HS256 / ES256 / RS256 / EdDSA + live JWKS rotation) | shipped |
 | Native iOS / Android SDKs | community-maintained |
 

--- a/apps/duck/content/docs/duck-auth/providers/index.mdx
+++ b/apps/duck/content/docs/duck-auth/providers/index.mdx
@@ -26,13 +26,13 @@ You register providers on `AuthEngine`:
 
 ```typescript
 import { password } from '@gentleduck/auth/providers/password'
-import { google } from '@gentleduck/auth/providers/oauth/google'
+import { authGoogle } from '@gentleduck/auth/providers/oauth/google'
 
 export const auth = new AuthEngine({
   // ...
   providers: [
     password({ ... }),
-    google({ ... }),
+    authGoogle({ ... }),
   ],
 })
 
@@ -97,7 +97,7 @@ For OAuth, SAML, and other federated providers, `onSignIn` is the
 extension point that lets you provision identities just-in-time:
 
 ```typescript
-google({
+authGoogle({
   // ...
   onSignIn: async ({ profile, tenantId }) => {
     let identity = await auth.identities.findByProviderSub({
@@ -129,7 +129,7 @@ session and emits the intents.
 your typed `Profile` generic:
 
 ```typescript
-google({
+authGoogle({
   // ...
   profileToIdentityProfile: (profile) => ({
     displayName: profile.name,

--- a/apps/duck/content/docs/duck-auth/providers/magic-link.mdx
+++ b/apps/duck/content/docs/duck-auth/providers/magic-link.mdx
@@ -8,14 +8,14 @@ section: Providers
 
 ```typescript
 import { magicLink } from '@gentleduck/auth/providers/magic-link'
-import { ResendChannel } from '@gentleduck/auth/channels/resend'
+import { AuthResendChannel } from '@gentleduck/auth/channels/resend'
 
 export const auth = new AuthEngine({
   // ...
   providers: [
     magicLink({
       channels: {
-        email: new ResendChannel({
+        email: new AuthResendChannel({
           apiKey: process.env.RESEND_API_KEY!,
           from: 'no-reply@example.com',
         }),
@@ -68,9 +68,9 @@ Pass `email`, `sms`, and `webpush` channels; the client picks one:
 ```typescript
 magicLink({
   channels: {
-    email: new ResendChannel({ ... }),
-    sms: new TwilioChannel({ ... }),
-    webpush: new WebPushChannel({ ... }),
+    email: new AuthResendChannel({ ... }),
+    sms: new AuthTwilioChannel({ ... }),
+    webpush: new AuthWebPushChannel({ ... }),
   },
   // ...
 })

--- a/apps/duck/content/docs/duck-auth/providers/oauth/apple.mdx
+++ b/apps/duck/content/docs/duck-auth/providers/oauth/apple.mdx
@@ -18,13 +18,13 @@ section: Providers
    and your team id.
 
 ```typescript
-import { apple } from '@gentleduck/auth/providers/oauth/apple'
+import { authApple } from '@gentleduck/auth/providers/oauth/apple'
 import { readFileSync } from 'node:fs'
 
 export const auth = new AuthEngine({
   // ...
   providers: [
-    apple({
+    authApple({
       clientId: 'com.example.app',                            // Services ID
       teamId: process.env.APPLE_TEAM_ID!,                     // 10-character team id
       keyId: process.env.APPLE_KEY_ID!,                       // 10-character key id
@@ -76,11 +76,11 @@ export const auth = new AuthEngine({
 
 ```typescript
 // Express
-app.post('/auth/apple/callback', mountSignIn(auth))
+app.post('/auth/apple/callback', authMountSignIn(auth))
 
 // Next.js
 // app/auth/apple/callback/route.ts
-export const POST = nextSignIn(auth)
+export const POST = authNextSignIn(auth)
 ```
 
 ## Required: ASCII Apple JS button

--- a/apps/duck/content/docs/duck-auth/providers/oauth/discord.mdx
+++ b/apps/duck/content/docs/duck-auth/providers/oauth/discord.mdx
@@ -13,12 +13,12 @@ section: Providers
 4. Copy the client ID and client secret.
 
 ```typescript
-import { discord } from '@gentleduck/auth/providers/oauth/discord'
+import { authDiscord } from '@gentleduck/auth/providers/oauth/discord'
 
 export const auth = new AuthEngine({
   // ...
   providers: [
-    discord({
+    authDiscord({
       clientId: process.env.DISCORD_CLIENT_ID!,
       clientSecret: process.env.DISCORD_CLIENT_SECRET!,
       redirectUri: 'https://app.example.com/auth/discord/callback',
@@ -77,7 +77,7 @@ Discord's `/users/@me`:
 If your app should only allow members of a specific Discord server:
 
 ```typescript
-discord({
+authDiscord({
   // ...
   scopes: ['identify', 'email', 'guilds'],
   onSignIn: async ({ profile }) => {

--- a/apps/duck/content/docs/duck-auth/providers/oauth/github.mdx
+++ b/apps/duck/content/docs/duck-auth/providers/oauth/github.mdx
@@ -14,12 +14,12 @@ section: Providers
 4. Copy the client ID and client secret.
 
 ```typescript
-import { github } from '@gentleduck/auth/providers/oauth/github'
+import { authGithub } from '@gentleduck/auth/providers/oauth/github'
 
 export const auth = new AuthEngine({
   // ...
   providers: [
-    github({
+    authGithub({
       clientId: process.env.GITHUB_CLIENT_ID!,
       clientSecret: process.env.GITHUB_CLIENT_SECRET!,
       redirectUri: 'https://app.example.com/auth/github/callback',
@@ -64,10 +64,10 @@ Same shape as every other OAuth provider:
 
 ```typescript
 // Express
-app.get('/auth/github/callback', mountSignIn(auth))
+app.get('/auth/github/callback', authMountSignIn(auth))
 
 // Next.js - app/auth/github/callback/route.ts
-export const GET = nextSignIn(auth)
+export const GET = authNextSignIn(auth)
 ```
 
 ## What the profile contains

--- a/apps/duck/content/docs/duck-auth/providers/oauth/google.mdx
+++ b/apps/duck/content/docs/duck-auth/providers/oauth/google.mdx
@@ -12,12 +12,12 @@ section: Providers
 3. Copy the client ID and client secret.
 
 ```typescript
-import { google } from '@gentleduck/auth/providers/oauth/google'
+import { authGoogle } from '@gentleduck/auth/providers/oauth/google'
 
 export const auth = new AuthEngine({
   // ...
   providers: [
-    google({
+    authGoogle({
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
       redirectUri: 'https://app.example.com/auth/google/callback',
@@ -54,22 +54,22 @@ export const auth = new AuthEngine({
 ## Callback route
 
 ```typescript title="Express"
-import { mountSignIn } from '@gentleduck/auth/server/express'
+import { authMountSignIn } from '@gentleduck/auth/server/express'
 
-app.get('/auth/google/callback', mountSignIn(auth))
+app.get('/auth/google/callback', authMountSignIn(auth))
 ```
 
 ```typescript title="Next.js"
 // app/auth/google/callback/route.ts
-import { nextSignIn } from '@gentleduck/auth/server/next'
-export const GET = nextSignIn(auth)
+import { authNextSignIn } from '@gentleduck/auth/server/next'
+export const GET = authNextSignIn(auth)
 ```
 
 ## Triggering sign-in
 
 ```typescript
 // React
-const begin = useBeginProvider()
+const begin = authUseBeginProvider()
 <button onClick={() => begin.mutate({ providerId: 'google', input: {} })}>
   Sign in with Google
 </button>
@@ -119,8 +119,8 @@ If you have a separate Google project for staging vs production, use
 two providers with different `providerId`s:
 
 ```typescript
-google({ providerId: 'google-prod', clientId: ..., clientSecret: ... }),
-google({ providerId: 'google-staging', clientId: ..., clientSecret: ... }),
+authGoogle({ providerId: 'google-prod', clientId: ..., clientSecret: ... }),
+authGoogle({ providerId: 'google-staging', clientId: ..., clientSecret: ... }),
 ```
 
 The runtime keys them separately; the client picks via
@@ -137,7 +137,7 @@ If you don't need refresh tokens (you only need a one-shot sign-in),
 override the begin call:
 
 ```typescript
-google({
+authGoogle({
   // ...
   extraAuthParams: { access_type: 'online' },
 })

--- a/apps/duck/content/docs/duck-auth/providers/oauth/index.mdx
+++ b/apps/duck/content/docs/duck-auth/providers/oauth/index.mdx
@@ -25,9 +25,9 @@ Every OAuth provider takes the same shape (with provider-specific defaults
 already applied):
 
 ```typescript
-import { google } from '@gentleduck/auth/providers/oauth/google'
+import { authGoogle } from '@gentleduck/auth/providers/oauth/google'
 
-google({
+authGoogle({
   clientId: process.env.GOOGLE_CLIENT_ID!,
   clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
   redirectUri: 'https://app.example.com/auth/google/callback',

--- a/apps/duck/content/docs/duck-auth/providers/oauth/linkedin.mdx
+++ b/apps/duck/content/docs/duck-auth/providers/oauth/linkedin.mdx
@@ -13,12 +13,12 @@ section: Providers
 4. Copy the client ID and client secret.
 
 ```typescript
-import { linkedin } from '@gentleduck/auth/providers/oauth/linkedin'
+import { authLinkedin } from '@gentleduck/auth/providers/oauth/linkedin'
 
 export const auth = new AuthEngine({
   // ...
   providers: [
-    linkedin({
+    authLinkedin({
       clientId: process.env.LINKEDIN_CLIENT_ID!,
       clientSecret: process.env.LINKEDIN_CLIENT_SECRET!,
       redirectUri: 'https://app.example.com/auth/linkedin/callback',

--- a/apps/duck/content/docs/duck-auth/providers/oauth/microsoft.mdx
+++ b/apps/duck/content/docs/duck-auth/providers/oauth/microsoft.mdx
@@ -13,12 +13,12 @@ section: Providers
 4. Note the **Application (client) ID** and the **Directory (tenant) ID**.
 
 ```typescript
-import { microsoft } from '@gentleduck/auth/providers/oauth/microsoft'
+import { authMicrosoft } from '@gentleduck/auth/providers/oauth/microsoft'
 
 export const auth = new AuthEngine({
   // ...
   providers: [
-    microsoft({
+    authMicrosoft({
       clientId: process.env.MICROSOFT_CLIENT_ID!,
       clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
       tenant: process.env.MICROSOFT_TENANT_ID!,   // or 'common' for multi-tenant

--- a/apps/duck/content/docs/duck-auth/server/express.mdx
+++ b/apps/duck/content/docs/duck-auth/server/express.mdx
@@ -9,28 +9,28 @@ section: Server
 ```typescript
 import express from 'express'
 import {
-  mountProviderBegin,
-  mountSession,
-  mountSignIn,
-  mountSignOut,
+  authMountProviderBegin,
+  authMountSession,
+  authMountSignIn,
+  authMountSignOut,
 } from '@gentleduck/auth/server/express'
 import { auth } from './lib/auth'
 
 const app = express()
 app.use(express.json())                  // duck-auth expects JSON bodies
 
-app.post('/auth/signin', mountSignIn(auth))
-app.post('/auth/signout', mountSignOut(auth))
-app.get('/auth/session', mountSession(auth))
+app.post('/auth/signin', authMountSignIn(auth))
+app.post('/auth/signout', authMountSignOut(auth))
+app.get('/auth/session', authMountSession(auth))
 
 // Provider begin: redirect to OAuth IdP, send a magic link, etc.
 app.post('/auth/providers/:providerId/begin', (req, res, next) => {
-  return mountProviderBegin(auth, req.params.providerId)(req, res, next)
+  return authMountProviderBegin(auth, req.params.providerId)(req, res, next)
 })
 
 // OAuth callback: re-use the sign-in handler with the providerId pre-set.
-app.get('/auth/google/callback', mountSignIn(auth))
-app.get('/auth/github/callback', mountSignIn(auth))
+app.get('/auth/google/callback', authMountSignIn(auth))
+app.get('/auth/github/callback', authMountSignIn(auth))
 
 app.listen(3000)
 ```
@@ -66,7 +66,7 @@ app.use((err, req, res, next) => {
 For custom routes where you need to drive the runtime by hand:
 
 ```typescript
-import { applyIntents } from '@gentleduck/auth/server/express'
+import { authApplyIntents } from '@gentleduck/auth/server/express'
 
 app.post('/auth/custom', async (req, res, next) => {
   try {
@@ -74,26 +74,26 @@ app.post('/auth/custom', async (req, res, next) => {
       providerId: 'password',
       input: req.body,
     })
-    applyIntents(intents, res)
+    authApplyIntents(intents, res)
   } catch (err) {
     next(err)
   }
 })
 ```
 
-`applyIntents` mutates `res` - it sets cookies via `res.cookie(...)`,
+`authApplyIntents` mutates `res` - it sets cookies via `res.cookie(...)`,
 writes the JSON body, sets status and headers. Equivalent to what the
 shipped mount helpers do internally.
 
 ## CSRF guard
 
 ```typescript
-import { csrfGuard } from '@gentleduck/auth/core'
+import { authCsrfGuard } from '@gentleduck/auth/core'
 
 app.use(async (req, res, next) => {
   if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
     try {
-      await csrfGuard(auth, req)
+      await authCsrfGuard(auth, req)
     } catch (err) {
       next(err)
       return

--- a/apps/duck/content/docs/duck-auth/server/generic.mdx
+++ b/apps/duck/content/docs/duck-auth/server/generic.mdx
@@ -8,7 +8,7 @@ section: Server
 
 The generic adapter is the lowest-level mount point. It exposes:
 
-- `executeIntents(intents, baseStatus?) -> Response` - turn `Intent[]`
+- `authExecuteIntents(intents, baseStatus?) -> Response` - turn `Intent[]`
   into a `Response`.
 - `parseSignInBody(raw)` - validate a sign-in JSON payload.
 - `parseProviderBeginBody(raw)` - validate a provider-begin payload.
@@ -24,7 +24,7 @@ Use it when:
 ## Bun (native)
 
 ```typescript
-import { executeIntents, parseSignInBody } from '@gentleduck/auth/server/generic'
+import { authExecuteIntents, parseSignInBody } from '@gentleduck/auth/server/generic'
 import { auth } from './lib/auth'
 
 Bun.serve({
@@ -37,7 +37,7 @@ Bun.serve({
       if (!body) return new Response('Bad Request', { status: 400 })
 
       const intents = await auth.flows.signIn(body)
-      return executeIntents(intents)
+      return authExecuteIntents(intents)
     }
 
     if (url.pathname === '/auth/session' && req.method === 'GET') {
@@ -54,7 +54,7 @@ Bun.serve({
 ## Deno
 
 ```typescript
-import { executeIntents } from '@gentleduck/auth/server/generic'
+import { authExecuteIntents } from '@gentleduck/auth/server/generic'
 import { auth } from './lib/auth.ts'
 
 Deno.serve({ port: 3000 }, async (req) => {
@@ -62,7 +62,7 @@ Deno.serve({ port: 3000 }, async (req) => {
   if (url.pathname === '/auth/signin' && req.method === 'POST') {
     const body = await req.json()
     const intents = await auth.flows.signIn(body)
-    return executeIntents(intents)
+    return authExecuteIntents(intents)
   }
   // ...
   return new Response('Not Found', { status: 404 })
@@ -72,7 +72,7 @@ Deno.serve({ port: 3000 }, async (req) => {
 ## Cloudflare Workers
 
 ```typescript
-import { executeIntents } from '@gentleduck/auth/server/generic'
+import { authExecuteIntents } from '@gentleduck/auth/server/generic'
 
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
@@ -81,7 +81,7 @@ export default {
 
     if (url.pathname === '/auth/signin' && req.method === 'POST') {
       const intents = await auth.flows.signIn(await req.json())
-      return executeIntents(intents)
+      return authExecuteIntents(intents)
     }
     return new Response('Not Found', { status: 404 })
   },
@@ -93,9 +93,9 @@ export default {
 If you need to wrap the response or add headers:
 
 ```typescript
-import { executeIntents } from '@gentleduck/auth/server/generic'
+import { authExecuteIntents } from '@gentleduck/auth/server/generic'
 
-const baseResponse = executeIntents(intents)
+const baseResponse = authExecuteIntents(intents)
 
 // Read the body, wrap it, return a new Response with the same headers.
 const wrapped = new Response(

--- a/apps/duck/content/docs/duck-auth/server/hono.mdx
+++ b/apps/duck/content/docs/duck-auth/server/hono.mdx
@@ -9,25 +9,25 @@ section: Server
 ```typescript
 import { Hono } from 'hono'
 import {
-  honoProviderBegin,
-  honoSession,
-  honoSignIn,
-  honoSignOut,
+  authHonoProviderBegin,
+  authHonoSession,
+  authHonoSignIn,
+  authHonoSignOut,
 } from '@gentleduck/auth/server/hono'
 import { auth } from './lib/auth'
 
 const app = new Hono()
 
-app.post('/auth/signin', honoSignIn(auth))
-app.post('/auth/signout', honoSignOut(auth))
-app.get('/auth/session', honoSession(auth))
+app.post('/auth/signin', authHonoSignIn(auth))
+app.post('/auth/signout', authHonoSignOut(auth))
+app.get('/auth/session', authHonoSession(auth))
 app.post('/auth/providers/:providerId/begin', (c) =>
-  honoProviderBegin(auth, c.req.param('providerId'))(c)
+  authHonoProviderBegin(auth, c.req.param('providerId'))(c)
 )
 
 // OAuth callbacks reuse the sign-in handler.
-app.get('/auth/google/callback', honoSignIn(auth))
-app.get('/auth/github/callback', honoSignIn(auth))
+app.get('/auth/google/callback', authHonoSignIn(auth))
+app.get('/auth/github/callback', authHonoSignIn(auth))
 
 export default app
 ```
@@ -52,8 +52,8 @@ that natively, so no adapter glue is needed.
 Hono on Cloudflare Workers is well-supported, but there are two gotchas
 for duck-auth:
 
-1. **No Node built-ins**: `ScryptHasher` uses `node:crypto`. On Workers,
-   either use `Argon2idHasher` (peer dep), or use a custom WebCrypto-based
+1. **No Node built-ins**: `AuthScryptHasher` uses `node:crypto`. On Workers,
+   either use `AuthArgon2idHasher` (peer dep), or use a custom WebCrypto-based
    hasher.
 2. **No `process.env`**: read secrets from `c.env` instead:
 
@@ -71,7 +71,7 @@ app.use('*', async (c, next) => {
 })
 
 app.post('/auth/signin', async (c) => {
-  return honoSignIn(c.get('auth'))(c)
+  return authHonoSignIn(c.get('auth'))(c)
 })
 ```
 

--- a/apps/duck/content/docs/duck-auth/server/index.mdx
+++ b/apps/duck/content/docs/duck-auth/server/index.mdx
@@ -10,13 +10,13 @@ Every server adapter exposes the same four routes:
 
 | Route | Handler |
 | --- | --- |
-| `POST /<prefix>/signin` | `mountSignIn(auth)` - completes provider sign-in. |
-| `POST /<prefix>/signout` | `mountSignOut(auth)` - revokes the current session. |
-| `GET /<prefix>/session` | `mountSession(auth)` - returns the current session + identity. |
-| `POST /<prefix>/providers/:providerId/begin` | `mountProviderBegin(auth, providerId)` - initiates a flow (OAuth redirect, magic-link send). |
+| `POST /<prefix>/signin` | `authMountSignIn(auth)` - completes provider sign-in. |
+| `POST /<prefix>/signout` | `authMountSignOut(auth)` - revokes the current session. |
+| `GET /<prefix>/session` | `authMountSession(auth)` - returns the current session + identity. |
+| `POST /<prefix>/providers/:providerId/begin` | `authMountProviderBegin(auth, providerId)` - initiates a flow (OAuth redirect, magic-link send). |
 
 The actual Express / Hono / Next functions are named consistently:
-`mountSignIn` / `honoSignIn` / `nextSignIn` etc. - they all return a
+`authMountSignIn` / `authHonoSignIn` / `authNextSignIn` etc. - they all return a
 handler appropriate to the framework.
 
 ## Shipped adapters
@@ -38,10 +38,10 @@ handler appropriate to the framework.
 Every adapter is a thin wrapper around the same core executor:
 
 ```typescript
-import { executeIntents } from '@gentleduck/auth/server/generic'
+import { authExecuteIntents } from '@gentleduck/auth/server/generic'
 
 const intents = await auth.flows.signIn({ providerId, input })
-const response = executeIntents(intents)
+const response = authExecuteIntents(intents)
 // -> web standard Response object with the right cookies / redirects / body
 ```
 
@@ -53,7 +53,7 @@ The intent executor handles:
 - `setCookie` / `header` -> raw additions.
 
 You can implement an adapter for an unsupported framework by calling
-`executeIntents()` and mapping the resulting `Response` to your
+`authExecuteIntents()` and mapping the resulting `Response` to your
 runtime's primitives.
 
 ## Path prefix
@@ -62,22 +62,22 @@ The mount helpers don't care about path - you mount at any prefix:
 
 ```typescript
 // Express
-app.post('/auth/signin', mountSignIn(auth))
-app.post('/auth/signout', mountSignOut(auth))
-app.get('/auth/session', mountSession(auth))
-app.post('/auth/providers/:providerId/begin', mountProviderBegin(auth, req.params.providerId))
+app.post('/auth/signin', authMountSignIn(auth))
+app.post('/auth/signout', authMountSignOut(auth))
+app.get('/auth/session', authMountSession(auth))
+app.post('/auth/providers/:providerId/begin', authMountProviderBegin(auth, req.params.providerId))
 
 // Or:
-app.post('/api/v1/auth/signin', mountSignIn(auth))
+app.post('/api/v1/auth/signin', authMountSignIn(auth))
 ```
 
 The OpenAPI generator uses the `prefix` config (default `/auth`) to
 emit the right paths in the spec:
 
 ```typescript
-import { buildOpenApiSpec } from '@gentleduck/auth/openapi'
+import { authBuildOpenApiSpec } from '@gentleduck/auth/openapi'
 
-const spec = buildOpenApiSpec({
+const spec = authBuildOpenApiSpec({
   baseUrl: 'https://api.example.com',
   prefix: '/api/v1/auth',
 })

--- a/apps/duck/content/docs/duck-auth/server/koa.mdx
+++ b/apps/duck/content/docs/duck-auth/server/koa.mdx
@@ -11,10 +11,10 @@ import Koa from 'koa'
 import Router from '@koa/router'
 import bodyParser from 'koa-bodyparser'
 import {
-  koaProviderBegin,
-  koaSession,
-  koaSignIn,
-  koaSignOut,
+  authKoaProviderBegin,
+  authKoaSession,
+  authKoaSignIn,
+  authKoaSignOut,
 } from '@gentleduck/auth/server/koa'
 import { auth } from './lib/auth'
 
@@ -23,14 +23,14 @@ const router = new Router()
 
 app.use(bodyParser())
 
-router.post('/auth/signin', koaSignIn(auth))
-router.post('/auth/signout', koaSignOut(auth))
-router.get('/auth/session', koaSession(auth))
+router.post('/auth/signin', authKoaSignIn(auth))
+router.post('/auth/signout', authKoaSignOut(auth))
+router.get('/auth/session', authKoaSession(auth))
 router.post('/auth/providers/:providerId/begin', (ctx) =>
-  koaProviderBegin(auth, ctx.params.providerId)(ctx),
+  authKoaProviderBegin(auth, ctx.params.providerId)(ctx),
 )
 // OAuth callbacks reuse the sign-in handler.
-router.get('/auth/google/callback', koaSignIn(auth))
+router.get('/auth/google/callback', authKoaSignIn(auth))
 
 app.use(router.routes())
 app.use(router.allowedMethods())

--- a/apps/duck/content/docs/duck-auth/server/next.mdx
+++ b/apps/duck/content/docs/duck-auth/server/next.mdx
@@ -10,10 +10,10 @@ The simplest mount is a single catch-all route handler that dispatches
 to the right duck-auth handler:
 
 ```typescript title="app/api/auth/[...auth]/route.ts"
-import { mountNext } from '@gentleduck/auth/server/next'
+import { authMountNext } from '@gentleduck/auth/server/next'
 import { auth } from '~/lib/auth'
 
-export const { GET, POST } = mountNext(auth)
+export const { GET, POST } = authMountNext(auth)
 ```
 
 This installs handlers for `signin`, `signout`, `session`, and
@@ -26,27 +26,27 @@ If you need per-route control (different rate-limit middleware, custom
 logging), mount each handler separately:
 
 ```typescript title="app/api/auth/signin/route.ts"
-import { nextSignIn } from '@gentleduck/auth/server/next'
+import { authNextSignIn } from '@gentleduck/auth/server/next'
 import { auth } from '~/lib/auth'
 
-export const POST = nextSignIn(auth)
+export const POST = authNextSignIn(auth)
 ```
 
 ```typescript title="app/api/auth/signout/route.ts"
-import { nextSignOut } from '@gentleduck/auth/server/next'
-export const POST = nextSignOut(auth)
+import { authNextSignOut } from '@gentleduck/auth/server/next'
+export const POST = authNextSignOut(auth)
 ```
 
 ```typescript title="app/api/auth/session/route.ts"
-import { nextSession } from '@gentleduck/auth/server/next'
-export const GET = nextSession(auth)
+import { authNextSession } from '@gentleduck/auth/server/next'
+export const GET = authNextSession(auth)
 ```
 
 ```typescript title="app/api/auth/providers/[providerId]/begin/route.ts"
-import { nextProviderBegin } from '@gentleduck/auth/server/next'
+import { authNextProviderBegin } from '@gentleduck/auth/server/next'
 
 export async function POST(req: Request, { params }: { params: { providerId: string } }) {
-  return nextProviderBegin(auth, params.providerId)(req)
+  return authNextProviderBegin(auth, params.providerId)(req)
 }
 ```
 
@@ -56,8 +56,8 @@ Each OAuth provider redirects back to a callback URL. Mount the sign-in
 handler under each callback path so the redirect resolves cleanly:
 
 ```typescript title="app/api/auth/google/callback/route.ts"
-import { nextSignIn } from '@gentleduck/auth/server/next'
-export const GET = nextSignIn(auth)
+import { authNextSignIn } from '@gentleduck/auth/server/next'
+export const GET = authNextSignIn(auth)
 ```
 
 The provider extracts `code`, `state`, and the PKCE verifier from the
@@ -140,11 +140,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
 ```tsx title="components/SignInButton.tsx"
 'use client'
 
-import { useSession, useSignIn } from '@gentleduck/auth/client/react'
+import { authUseSession, authUseSignIn } from '@gentleduck/auth/client/react'
 
 export function SignInButton() {
-  const { data, status } = useSession()
-  const signIn = useSignIn()
+  const { data, status } = authUseSession()
+  const signIn = authUseSignIn()
 
   if (status === 'authed') return <span>Hi, {data.identity.profile.displayName}</span>
   return (

--- a/apps/duck/content/docs/duck-iam/advanced/devtools.mdx
+++ b/apps/duck/content/docs/duck-iam/advanced/devtools.mdx
@@ -49,12 +49,12 @@ real engine.
 
 | Panel | What it shows |
 |---|---|
-| **Flow** | A live stream of every `can` / `check` / `authorize` call: subject, action, resource, the resulting decision, and the matched policy / rule. Backed by `createFlowRecorder`. |
+| **Flow** | A live stream of every `can` / `check` / `authorize` call: subject, action, resource, the resulting decision, and the matched policy / rule. Backed by `iamCreateFlowRecorder`. |
 | **Decision** | A request builder: pick a subject, action, resource, environment. Hit "Run" to see the decision + the rule that matched. Calls `engine.explain()`. |
 | **Policies** | All policies loaded into the engine. Click one to see its rules + targets. |
 | **Roles** | All roles loaded into the engine, including inheritance chains and the synthetic policies they expand to. |
 | **Subjects** | Subjects you've inspected, with their resolved roles + attributes. |
-| **Metrics** | `createMetricsAggregator()` snapshot: p50 / p95 / p99 + allow / deny counts. |
+| **Metrics** | `iamCreateMetricsAggregator()` snapshot: p50 / p95 / p99 + allow / deny counts. |
 
 ## Position & layout
 
@@ -85,14 +85,14 @@ admin UI rather than a floating overlay.
 ## Wiring metrics
 
 The Metrics panel reads from any `IDevtoolsMetrics` instance. The
-shipping `createMetricsAggregator` from `@gentleduck/iam/observability/metrics`
+shipping `iamCreateMetricsAggregator` from `@gentleduck/iam/observability/metrics`
 matches the shape, so the two compose:
 
 ```tsx
-import { createMetricsAggregator } from '@gentleduck/iam/observability/metrics'
+import { iamCreateMetricsAggregator } from '@gentleduck/iam/observability/metrics'
 import { IamDevtools } from '@gentleduck/iam/dt'
 
-const metrics = createMetricsAggregator()
+const metrics = iamCreateMetricsAggregator()
 const engine = new IamEngine({
   adapter,
   hooks: { onMetrics: metrics.record },
@@ -107,13 +107,13 @@ for the full hook surface.
 ## Wiring the flow recorder
 
 The Flow panel needs an `IFlowRecorder`. Build one via
-`createFlowRecorder` and pass it both as the engine hook bus and as
+`iamCreateFlowRecorder` and pass it both as the engine hook bus and as
 the devtools prop:
 
 ```tsx
-import { createFlowRecorder } from '@gentleduck/iam/dt'
+import { iamCreateFlowRecorder } from '@gentleduck/iam/dt'
 
-const flow = createFlowRecorder({ maxEntries: 500 })
+const flow = iamCreateFlowRecorder({ maxEntries: 500 })
 
 const engine = new IamEngine({
   adapter,
@@ -136,12 +136,12 @@ For when you don't want a floating overlay - export the inner
 component and use the three sub-panel renderers directly:
 
 ```tsx
-import { IamDevtoolsInner, DecisionInspector, FlowPanel, MetricsPanel } from '@gentleduck/iam/dt'
+import { IamDevtoolsInner, IamDecisionInspector, IamFlowPanel, IamMetricsPanel } from '@gentleduck/iam/dt'
 
 <Tabs>
-  <Tab title="Decision"><DecisionInspector engine={engine} /></Tab>
-  <Tab title="Flow"><FlowPanel flow={flow} /></Tab>
-  <Tab title="Metrics"><MetricsPanel metrics={metrics} /></Tab>
+  <Tab title="Decision"><IamDecisionInspector engine={engine} /></Tab>
+  <Tab title="Flow"><IamFlowPanel flow={flow} /></Tab>
+  <Tab title="Metrics"><IamMetricsPanel metrics={metrics} /></Tab>
 </Tabs>
 ```
 

--- a/apps/duck/content/docs/duck-iam/advanced/engine/index.mdx
+++ b/apps/duck/content/docs/duck-iam/advanced/engine/index.mdx
@@ -217,11 +217,11 @@ In production mode, `engine.authorize()` returns a plain `boolean` - no `IDecisi
 Most applications only need the `IamEngine`, but two adjacent exports are worth knowing about:
 
 ```typescript
-import { LRUCache, buildPermissionKey } from '@gentleduck/iam'
+import { IamLRUCache, iamBuildPermissionKey } from '@gentleduck/iam'
 ```
 
-- `buildPermissionKey(action, resource, resourceId?, scope?)` matches the exact key format used by `engine.permissions()` and all client libraries
-- `LRUCache` is the small TTL cache implementation the engine uses internally - import only if you want the same eviction semantics in neighboring application code
+- `iamBuildPermissionKey(action, resource, resourceId?, scope?)` matches the exact key format used by `engine.permissions()` and all client libraries
+- `IamLRUCache` is the small TTL cache implementation the engine uses internally - import only if you want the same eviction semantics in neighboring application code
 
 ---
 

--- a/apps/duck/content/docs/duck-iam/advanced/engine/methods.mdx
+++ b/apps/duck/content/docs/duck-iam/advanced/engine/methods.mdx
@@ -124,7 +124,7 @@ interface PermissionCheck<
 
 This is the method to use when rendering a UI that needs many permissions at once (which buttons to show/hide). It's also what server middleware uses to generate `PermissionMap` objects for client hydration.
 
-The returned map uses the same key format as the client libraries and the root-level `buildPermissionKey()` helper. If you're writing custom hydration code, tests, or a framework integration outside the shipped clients, prefer that helper instead of hand-building key strings.
+The returned map uses the same key format as the client libraries and the root-level `iamBuildPermissionKey()` helper. If you're writing custom hydration code, tests, or a framework integration outside the shipped clients, prefer that helper instead of hand-building key strings.
 
 ### With scopes and resource IDs
 
@@ -226,11 +226,11 @@ engine.cache.invalidateRoles(roleId?, opts?)     // drop cached roles + RBAC pol
 
 With an `invalidator` wired, each call publishes an event so peer instances flush their local caches. Pass `{ broadcast: false }` to suppress the publish when *applying* an inbound event (otherwise instances ping-pong).
 
-Module-level `flushSharedCaches()` (separate import) wipes the **process-wide** regex + path caches shared across every Engine. Schedule periodically in multi-tenant deployments.
+Module-level `iamFlushSharedCaches()` (separate import) wipes the **process-wide** regex + path caches shared across every Engine. Schedule periodically in multi-tenant deployments.
 
 ```typescript
-import { flushSharedCaches } from '@gentleduck/iam'
-setInterval(flushSharedCaches, 5 * 60 * 1000)
+import { iamFlushSharedCaches } from '@gentleduck/iam'
+setInterval(iamFlushSharedCaches, 5 * 60 * 1000)
 ```
 
 ---

--- a/apps/duck/content/docs/duck-iam/advanced/explain.mdx
+++ b/apps/duck/content/docs/duck-iam/advanced/explain.mdx
@@ -8,7 +8,7 @@ section: Advanced
 When a permission check returns the wrong answer, duck-iam ships two debugging tools:
 
 <MermaidDiagram chart={`flowchart LR
-    subgraph Result["IamExplain.IResult"]
+    subgraph Result["Explain.IResult"]
         direction TB
         DEC["decision\nallowed, effect, duration"]
         REQ["request\naction, resource, scope"]
@@ -16,10 +16,10 @@ When a permission check returns the wrong answer, duck-iam ships two debugging t
         SUM["summary\nhuman-readable text"]
     end
 
-    subgraph Policies["policies: IamExplain.IPolicyTrace[]"]
+    subgraph Policies["policies: Explain.IPolicyTrace[]"]
         direction TB
         PT["IPolicyTrace\npolicyId, algorithm, targetMatch"]
-        PT --> PT_R["rules: IamExplain.IRuleTrace[]"]
+        PT --> PT_R["rules: Explain.IRuleTrace[]"]
         PT --> PT_RES["result: allow / deny"]
     end
 
@@ -62,7 +62,7 @@ const result = await engine.explain('user-1', 'delete', {
 })
 ```
 
-### The IamExplain.IResult
+### The Explain.IResult
 
 ```typescript
 interface IResult {
@@ -79,7 +79,7 @@ interface IResult {
     scopedRolesApplied: string[]      // Extra roles added from scoped assignments
     attributes: Record<string, any>
   }
-  policies: IamExplain.IPolicyTrace[]    // Trace of every policy evaluated
+  policies: Explain.IPolicyTrace[]    // Trace of every policy evaluated
   summary: string                     // Human-readable multi-line summary
 }
 ```
@@ -124,9 +124,9 @@ This tells you:
 - The RBAC policy had 5 rules but none matched the `delete` action.
 - The `owner-policy` matched, and rule `deny-non-owner-delete` produced the deny.
 
-### Reading IamExplain.IPolicyTrace
+### Reading Explain.IPolicyTrace
 
-Each entry in `result.policies` is an `IamExplain.IPolicyTrace`:
+Each entry in `result.policies` is an `Explain.IPolicyTrace`:
 
 ```typescript
 interface IPolicyTrace {
@@ -134,7 +134,7 @@ interface IPolicyTrace {
   policyName: string                          // Human-readable policy name
   algorithm: AccessControl.CombiningAlgorithm // deny-overrides, allow-overrides, etc.
   targetMatch: boolean                        // Did the policy's target filter match?
-  rules: IamExplain.IRuleTrace[]                 // Trace of every rule in this policy
+  rules: Explain.IRuleTrace[]                 // Trace of every rule in this policy
   result: 'allow' | 'deny'                    // The policy's final per-policy result
   reason: string                              // Human-readable explanation
   decidingRuleId?: string                     // Which rule determined the result
@@ -156,9 +156,9 @@ for (const pt of result.policies) {
 }
 ```
 
-### Reading IamExplain.IRuleTrace
+### Reading Explain.IRuleTrace
 
-Each rule inside a policy produces an `IamExplain.IRuleTrace`:
+Each rule inside a policy produces an `Explain.IRuleTrace`:
 
 ```typescript
 interface IRuleTrace {
@@ -169,7 +169,7 @@ interface IRuleTrace {
   actionMatch: boolean            // Did the rule's actions match the request action?
   resourceMatch: boolean          // Did the rule's resources match the request resource?
   conditionsMet: boolean          // Did all conditions evaluate to true?
-  conditions: IamExplain.IGroupTrace // Full condition tree trace
+  conditions: Explain.IGroupTrace // Full condition tree trace
   matched: boolean                // actionMatch && resourceMatch && conditionsMet
 }
 ```
@@ -200,7 +200,7 @@ interface IGroupTrace {
   type: 'group'
   logic: 'all' | 'any' | 'none'
   result: boolean
-  children: Array<IamExplain.ILeafTrace | IamExplain.IGroupTrace>
+  children: Array<Explain.ILeafTrace | Explain.IGroupTrace>
 }
 
 // Leaf node
@@ -290,11 +290,11 @@ The validate module also exports a handful of constants and a JSON Schema (Draft
 
 ```typescript
 import {
-  POLICY_JSON_SCHEMA,     // JSON Schema (Draft 2020-12) for AccessControl.IPolicy
-  POLICY_LIMITS,          // { rulesPerPolicy, actionsPerRule, resourcesPerRule, cartesianPerRule }
+  IAM_POLICY_JSON_SCHEMA,     // JSON Schema (Draft 2020-12) for AccessControl.IPolicy
+  IAM_POLICY_LIMITS,          // { rulesPerPolicy, actionsPerRule, resourcesPerRule, cartesianPerRule }
   MAX_INHERITANCE_DEPTH,  // 32 - cap used by INHERITANCE_TOO_DEEP
   MAX_CONDITION_DEPTH,    // 10 - cap on nested all/any/none groups
-  MAX_FIELD_LENGTH,       // 256 - cap on dot-path field length
+  IAM_MAX_FIELD_LENGTH,       // 256 - cap on dot-path field length
 } from '@gentleduck/iam'
 ```
 

--- a/apps/duck/content/docs/duck-iam/advanced/json-schema.mdx
+++ b/apps/duck/content/docs/duck-iam/advanced/json-schema.mdx
@@ -1,10 +1,10 @@
 ---
 title: JSON schema
-description: POLICY_JSON_SCHEMA - hand-authored JSON Schema (Draft 2020-12) for AccessControl.IPolicy. Wire into editors, admin forms, or out-of-band validators.
+description: IAM_POLICY_JSON_SCHEMA - hand-authored JSON Schema (Draft 2020-12) for AccessControl.IPolicy. Wire into editors, admin forms, or out-of-band validators.
 section: Advanced
 ---
 
-duck-iam exports `POLICY_JSON_SCHEMA` - a JSON Schema (Draft 2020-12)
+duck-iam exports `IAM_POLICY_JSON_SCHEMA` - a JSON Schema (Draft 2020-12)
 document that mirrors the runtime shape of `AccessControl.IPolicy`.
 It's useful for:
 
@@ -13,7 +13,7 @@ It's useful for:
 - **Admin dashboards** generating policy forms from the schema.
 
 ```typescript
-import { POLICY_JSON_SCHEMA } from '@gentleduck/iam/core/schema'
+import { IAM_POLICY_JSON_SCHEMA } from '@gentleduck/iam/core/schema'
 ```
 
 ## Why hand-authored?
@@ -28,23 +28,23 @@ sets.
 ## Tightening for your app
 
 ```typescript
-import { POLICY_JSON_SCHEMA } from '@gentleduck/iam/core/schema'
+import { IAM_POLICY_JSON_SCHEMA } from '@gentleduck/iam/core/schema'
 
 const myAppSchema = {
-  ...POLICY_JSON_SCHEMA,
+  ...IAM_POLICY_JSON_SCHEMA,
   $defs: {
-    ...POLICY_JSON_SCHEMA.$defs,
+    ...IAM_POLICY_JSON_SCHEMA.$defs,
     Action: { enum: ['create', 'read', 'update', 'delete'] },
     Resource: { enum: ['post', 'comment', 'user'] },
   },
   properties: {
-    ...POLICY_JSON_SCHEMA.properties,
+    ...IAM_POLICY_JSON_SCHEMA.properties,
     rules: {
       type: 'array',
       items: {
-        ...POLICY_JSON_SCHEMA.$defs.Rule,
+        ...IAM_POLICY_JSON_SCHEMA.$defs.Rule,
         properties: {
-          ...POLICY_JSON_SCHEMA.$defs.Rule.properties,
+          ...IAM_POLICY_JSON_SCHEMA.$defs.Rule.properties,
           actions: { type: 'array', items: { $ref: '#/$defs/Action' } },
           resources: { type: 'array', items: { $ref: '#/$defs/Resource' } },
         },

--- a/apps/duck/content/docs/duck-iam/advanced/validation.mdx
+++ b/apps/duck/content/docs/duck-iam/advanced/validation.mdx
@@ -112,16 +112,16 @@ same caps in their UI.
 
 | Constant | Value | What it caps |
 |---|---|---|
-| `POLICY_LIMITS.rulesPerPolicy` | 1_000 | rules per policy |
-| `POLICY_LIMITS.actionsPerRule` | 100 | actions per rule |
-| `POLICY_LIMITS.resourcesPerRule` | 100 | resources per rule |
-| `POLICY_LIMITS.cartesianPerRule` | 1_000 | actions x resources expansion |
-| `MAX_FIELD_LENGTH` | 256 | field-path strings |
-| `MAX_CONDITION_VALUE_LENGTH` | 1024 | string condition values |
+| `IAM_POLICY_LIMITS.rulesPerPolicy` | 1_000 | rules per policy |
+| `IAM_POLICY_LIMITS.actionsPerRule` | 100 | actions per rule |
+| `IAM_POLICY_LIMITS.resourcesPerRule` | 100 | resources per rule |
+| `IAM_POLICY_LIMITS.cartesianPerRule` | 1_000 | actions x resources expansion |
+| `IAM_MAX_FIELD_LENGTH` | 256 | field-path strings |
+| `IAM_MAX_CONDITION_VALUE_LENGTH` | 1024 | string condition values |
 | `MAX_INHERITANCE_DEPTH` | 8 | role inherits chain depth |
 
 ```typescript
-import { POLICY_LIMITS, MAX_FIELD_LENGTH } from '@gentleduck/iam/core/validate'
+import { IAM_POLICY_LIMITS, IAM_MAX_FIELD_LENGTH } from '@gentleduck/iam/core/validate'
 ```
 
 ## ReDoS defense
@@ -134,9 +134,9 @@ string }` and `validatePolicy` calls it on every `matches` condition.
 The detector refuses common ReDoS shapes:
 - Nested quantifiers (`(a+)+`, `(a*)*`).
 - Alternation inside a quantifier (`(a|a)+`).
-- More than `MAX_UNBOUNDED_QUANTIFIERS` unbounded quantifiers (default 4) in one pattern.
+- More than `IAM_MAX_UNBOUNDED_QUANTIFIERS` unbounded quantifiers (default 4) in one pattern.
 - Backreference followed by a quantifier (`(\w+)\1+`).
-- Bounded quantifier with large upper bound (`a{1,1000000}`); cap is `MAX_BOUNDED_QUANTIFIER` (default 1_000).
+- Bounded quantifier with large upper bound (`a{1,1000000}`); cap is `IAM_MAX_BOUNDED_QUANTIFIER` (default 1_000).
 - Lookaround group containing a quantifier (`(?=(a+)+)`).
 
 Patterns deemed unsafe never compile, so the runtime never sees them.
@@ -160,7 +160,7 @@ them in your error handling so a code change is a deliberate event:
 | `INVALID_EFFECT` | Effect is not `'allow'` or `'deny'` |
 | `INVALID_OPERATOR` | Condition operator is not in the closed set |
 | `INVALID_CONDITION` | Condition group structure is malformed |
-| `LIMIT_EXCEEDED` | A `POLICY_LIMITS` cap was breached |
+| `LIMIT_EXCEEDED` | A `IAM_POLICY_LIMITS` cap was breached |
 | `UNSAFE_REGEX` | `detectCatastrophicRegex` rejected a pattern |
 
 The full `IamValidate.IIssue` type is exported from

--- a/apps/duck/content/docs/duck-iam/changelog.mdx
+++ b/apps/duck/content/docs/duck-iam/changelog.mdx
@@ -21,8 +21,8 @@ engine.invalidatePolicies(opts)            engine.cache.invalidatePolicies(opts)
 engine.invalidateRoles(id?, opts)          engine.cache.invalidateRoles(id?, opts)
 engine.stats()                             engine.stats.get()
 engine.resetStats()                        engine.stats.reset()
-engine.flushSharedCaches()                 // REMOVED
-                                           import { flushSharedCaches } from '@gentleduck/iam'
+engine.iamFlushSharedCaches()                 // REMOVED
+                                           import { iamFlushSharedCaches } from '@gentleduck/iam'
 ```
 
 Mechanical `sed` per call site - no behavior change. Codemod:
@@ -40,7 +40,7 @@ sed -i -E \
 
 #### Why 3.0 now
 
-- `flushSharedCaches` instance method was already scheduled for 3.0 removal - it was misleading (wiped process-globals, affecting every Engine in the process). Bundle the deprecation with the facet split: one major, one migration window.
+- `iamFlushSharedCaches` instance method was already scheduled for 3.0 removal - it was misleading (wiped process-globals, affecting every Engine in the process). Bundle the deprecation with the facet split: one major, one migration window.
 - Flat surface drops from 16 -> 9 methods + 2 facet handles. Leaves room for future facet growth (`engine.cache.prewarm()`, `engine.stats.subscribe()`) without polluting the root.
 
 #### What did not change
@@ -84,7 +84,7 @@ Plus 50+ smaller fixes covering cache races, listener swallow, audit string leak
 
 **Next `withAccess` requires `getUserId` at construction.** Throws otherwise with a message pointing to cookie/JWT-derived identity. **SEC-101.**
 
-**Admin routers CSRF-check by default.** `adminRouter` / `bindAdminRouter` / `createAdminHandlers` / `createAdminOperations` all apply `defaultCsrfCheck` (rejects `Sec-Fetch-Site: cross-site|cross-origin`). Bearer-token / mTLS APIs opt out via `csrfCheck: false`. Cookie-auth admin UIs get protection without any opt-in. **CAVEAT-2.**
+**Admin routers CSRF-check by default.** `adminRouter` / `bindAdminRouter` / `createAdminHandlers` / `createAdminOperations` all apply `iamDefaultCsrfCheck` (rejects `Sec-Fetch-Site: cross-site|cross-origin`). Bearer-token / mTLS APIs opt out via `csrfCheck: false`. Cookie-auth admin UIs get protection without any opt-in. **CAVEAT-2.**
 
 **`IamFileAdapter` no longer silently empties on errors.** Non-ENOENT readFile errors throw. JSON parse failure throws "store corrupt - refusing to load; restore from backup before retrying" instead of populating `_cache = {}` and risking permanent overwrite on next flush. **SEC-054 / SEC-064.**
 
@@ -92,16 +92,16 @@ Plus 50+ smaller fixes covering cache races, listener swallow, audit string leak
 
 **All 5 adapters' `getSubjectRoles` return unscoped-only.** Scoped assignments surface via `getSubjectScopedRoles` only. Was inconsistent across backends. **SEC-059.**
 
-**Engine ctor + LRUCache reject NaN/Infinity bounds.** `maxPolicies`, `maxRoles`, `adapterTimeoutMs`, `maxSize`, `ttlMs` all require finite numbers. NaN silently disabled the cap before. **INFO-A.**
+**Engine ctor + IamLRUCache reject NaN/Infinity bounds.** `maxPolicies`, `maxRoles`, `adapterTimeoutMs`, `maxSize`, `ttlMs` all require finite numbers. NaN silently disabled the cap before. **INFO-A.**
 
 ### New APIs
 
 ```ts
 // Engine: flush process-wide regex + path caches (multi-tenant)
-engine.flushSharedCaches()
+engine.iamFlushSharedCaches()
 
 // Server: built-in Sec-Fetch-Site CSRF predicate
-import { defaultCsrfCheck } from '@gentleduck/iam/server/generic'
+import { iamDefaultCsrfCheck } from '@gentleduck/iam/server/generic'
 
 // Admin router CSRF opt-out
 adminRouter(engine, { authorize, csrfCheck: false })
@@ -115,11 +115,11 @@ createIamRedisInvalidator({
 })
 
 // Metrics: fail-open chartable counter
-const m = createMetricsAggregator()
+const m = iamCreateMetricsAggregator()
 m.snapshot().failOpen  // subset of allow attributable to defaultEffect fallback
 
 // Shared keys: escape-aware key parser
-import { splitPermissionKey } from '@gentleduck/iam/shared/keys'
+import { iamSplitPermissionKey } from '@gentleduck/iam/shared/keys'
 
 // Low-level cache controls
 import { clearRegexCache } from '@gentleduck/iam/core/conditions'
@@ -187,7 +187,7 @@ If you relied on **`IamFileAdapter`** silently emptying on errors, wire `onPolic
 
 - **30+ fix commits** in this release on top of the 2.0.0 audit.
 - **0 P0/P1/P2/Low open** at release time.
-- **3 Info-tier residuals** (SEC-049 doc IPv6 prefix not publicly routed; SEC-050 architectural per-instance refactor deferred behind public `flushSharedCaches` helper).
+- **3 Info-tier residuals** (SEC-049 doc IPv6 prefix not publicly routed; SEC-050 architectural per-instance refactor deferred behind public `iamFlushSharedCaches` helper).
 
 ## 2.0.0
 
@@ -217,10 +217,10 @@ If you relied on **`IamFileAdapter`** silently emptying on errors, wire `onPolic
 - **`AccessControl.PolicyCombine`** - cross-policy combine strategy (`'and'` / `'allow-overrides'` / `'first-applicable'`). Configurable via `IamEngine.policyCombine`.
 - **`IamEngineTypes.IMetricsEvent` + `onMetrics` hook** - primitive-only telemetry payload fired once per evaluation in both dev and prod modes. Zero overhead when unwired.
 - **`IamFileAdapter`** at `@gentleduck/iam/adapters/file` - JSON-on-disk store with pluggable `IamFile.IFS` interface.
-- **`POLICY_JSON_SCHEMA`** - Draft 2020-12 JSON schema export for non-TS consumers and editor tooling.
+- **`IAM_POLICY_JSON_SCHEMA`** - Draft 2020-12 JSON schema export for non-TS consumers and editor tooling.
 - **`IamEngine.stats()` / `resetStats()`** - cache hit/miss counters per cache.
 - **Validator semantic checks** - emits `UNRESOLVABLE_FIELD`, `UNRESOLVABLE_VALUE`, `INHERITANCE_TOO_DEEP`, `BROAD_ALLOW`, `LIMIT_EXCEEDED` codes.
-- **`POLICY_LIMITS`** - DoS bounds (1000 rules/policy, 100 actions/rule, 100 resources/rule, 1000 action x resource cartesian/rule).
+- **`IAM_POLICY_LIMITS`** - DoS bounds (1000 rules/policy, 100 actions/rule, 100 resources/rule, 1000 action x resource cartesian/rule).
 - **`MAX_INHERITANCE_DEPTH = 32`** exported from `core/rbac`. Validator errors on chains that exceed it.
 
 **Build / package:**
@@ -243,7 +243,7 @@ If you relied on **`IamFileAdapter`** silently emptying on errors, wire `onPolic
 - `hooks.onMetrics` - primitive-only telemetry event fired once per evaluation in both modes.
 - IamHttpAdapter retry + per-request timeout + circuit-breaker (`retries`, `backoffMs`, `timeoutMs`, `circuitBreakerThreshold`, `circuitBreakerCooldownMs`).
 - `createIamRedisInvalidator` at `@gentleduck/iam/invalidators/redis` - pub/sub helper with self-echo filtering.
-- `createMetricsAggregator` at `@gentleduck/iam/observability/metrics` - p50 / p95 / p99 over `onMetrics` events.
+- `iamCreateMetricsAggregator` at `@gentleduck/iam/observability/metrics` - p50 / p95 / p99 over `onMetrics` events.
 - Hono `bindAdminRouter`, Next.js `createAdminHandlers`, NestJS `createAdminOperations` - all require `authorize` callback.
 - Express `adminRouter(engine, { authorize })` - `authorize` is now required (was optional).
 
@@ -251,7 +251,7 @@ If you relied on **`IamFileAdapter`** silently emptying on errors, wire `onPolic
 
 - `matches` operator refuses `$`-resolved RHS values (ReDoS via user-controlled regex).
 - IamHttpAdapter `getPolicy` / `getRole` return `null` on 404 instead of throwing.
-- Validator depth bound (`MAX_CONDITION_DEPTH=10`) and field-length cap (`MAX_FIELD_LENGTH=256`).
+- Validator depth bound (`MAX_CONDITION_DEPTH=10`) and field-length cap (`IAM_MAX_FIELD_LENGTH=256`).
 - Regex cache is LRU on hit, not FIFO on insert.
 - Synthesised RBAC policy is deep-frozen (every rule + conditions tree).
 - `Number.isFinite` priority check in validator.
@@ -301,7 +301,7 @@ Every new namespace is type-only (interfaces + type aliases only, no runtime val
 
 - 0e80f84: Add Redis adapter, Drizzle schemas, and full integration test coverage.
 
-  **New: `IamRedisAdapter`** at `@gentleduck/iam/adapters/redis`. Distributed key/value backend with idempotent `assignRole` (set semantics), multi-tenant `keyPrefix`, and a minimal `RedisLike` interface that ioredis, node-redis v4+, and Upstash all satisfy directly.
+  **New: `IamRedisAdapter`** at `@gentleduck/iam/adapters/redis`. Distributed key/value backend with idempotent `assignRole` (set semantics), multi-tenant `keyPrefix`, and a minimal `AuthRedisLike` interface that ioredis, node-redis v4+, and Upstash all satisfy directly.
 
   **New: pre-built Drizzle schemas** at `@gentleduck/iam/adapters/drizzle/schema/{pg,mysql,sqlite}`. Drop-in tables for all three SQL dialects with the right column types, FK cascade on `roleId`, unique index on `(subjectId, roleId, scope)`, and auto-managed `created_at`/`updated_at`. Generate migrations via `drizzle-kit generate`.
 

--- a/apps/duck/content/docs/duck-iam/core/evaluation.mdx
+++ b/apps/duck/content/docs/duck-iam/core/evaluation.mdx
@@ -150,6 +150,6 @@ console.log(trace.policies) // per-policy breakdowns
 console.log(trace.rules)    // per-rule match details
 ```
 
-`explain()` runs the same pipeline but builds a richer `IamExplain.IResult` trace instead of an `AccessControl.IDecision`. Side-effect hooks (`onDeny`, `afterEvaluate`) don't fire - it's read-only.
+`explain()` runs the same pipeline but builds a richer `Explain.IResult` trace instead of an `AccessControl.IDecision`. Side-effect hooks (`onDeny`, `afterEvaluate`) don't fire - it's read-only.
 
 See [explain and debug](/duck-iam/advanced/explain) for the full trace API.

--- a/apps/duck/content/docs/duck-iam/course/chapter-6.mdx
+++ b/apps/duck/content/docs/duck-iam/course/chapter-6.mdx
@@ -45,10 +45,10 @@ All server integrations share the same pattern:
 
 ### HTTP Method to Action Mapping
 
-duck-iam maps HTTP methods to actions automatically via `METHOD_ACTION_MAP`:
+duck-iam maps HTTP methods to actions automatically via `IAM_METHOD_ACTION_MAP`:
 
 ```typescript
-const METHOD_ACTION_MAP = {
+const IAM_METHOD_ACTION_MAP = {
   GET: 'read',
   HEAD: 'read',
   OPTIONS: 'read',
@@ -184,7 +184,7 @@ returns boolean either way, the rest of your code stays the same.
     interface ExpressOptions {
       getUserId?: (req) => string | null        // default: req.user?.id
       getResource?: (req) => Resource           // default: parse from URL
-      getAction?: (req) => string               // default: METHOD_ACTION_MAP
+      getAction?: (req) => string               // default: IAM_METHOD_ACTION_MAP
       getEnvironment?: (req) => Environment     // default: extractEnvironment()
       getScope?: (req) => string | undefined    // default: none
       onDenied?: (req, res) => void             // default: res.status(403).json(...)
@@ -322,20 +322,20 @@ returns boolean either way, the rest of your code stays the same.
 
     ```typescript title="src/access/access.module.ts"
     import { Module } from '@nestjs/common'
-    import { createEngineProvider, ACCESS_ENGINE_TOKEN } from '@gentleduck/iam/server/nest'
+    import { createEngineProvider, IAM_ACCESS_ENGINE_TOKEN } from '@gentleduck/iam/server/nest'
     import { engine } from './access'  // mode: 'production' recommended
 
     @Module({
       providers: [
         createEngineProvider(() => engine),
       ],
-      exports: [ACCESS_ENGINE_TOKEN],
+      exports: [IAM_ACCESS_ENGINE_TOKEN],
     })
     export class AccessModule {}
     ```
 
     `createEngineProvider()` returns a NestJS provider that makes the engine available
-    via dependency injection using the `ACCESS_ENGINE_TOKEN` injection token.
+    via dependency injection using the `IAM_ACCESS_ENGINE_TOKEN` injection token.
   </Step>
 
   <Step>
@@ -343,14 +343,14 @@ returns boolean either way, the rest of your code stays the same.
 
     ```typescript title="src/access/access.guard.ts"
     import { CanActivate, ExecutionContext, Injectable, Inject } from '@nestjs/common'
-    import { nestAccessGuard, ACCESS_ENGINE_TOKEN } from '@gentleduck/iam/server/nest'
+    import { nestAccessGuard, IAM_ACCESS_ENGINE_TOKEN } from '@gentleduck/iam/server/nest'
     import type { IamEngine } from '@gentleduck/iam'
 
     @Injectable()
     export class AccessGuard implements CanActivate {
       private check: ReturnType<typeof nestAccessGuard>
 
-      constructor(@Inject(ACCESS_ENGINE_TOKEN) engine: IamEngine) {
+      constructor(@Inject(IAM_ACCESS_ENGINE_TOKEN) engine: IamEngine) {
         this.check = nestAccessGuard(engine, {
           getUserId: (req) => req.user?.id || req.user?.sub,
           getScope: (req) => req.headers['x-organization'],
@@ -412,7 +412,7 @@ returns boolean either way, the rest of your code stays the same.
     ```
 
     When `@Authorize()` uses `infer: true` (the default), action is inferred from the HTTP method
-    via `METHOD_ACTION_MAP` and resource is inferred from the route path (last non-parameter segment).
+    via `IAM_METHOD_ACTION_MAP` and resource is inferred from the route path (last non-parameter segment).
 
     If no `@Authorize` decorator is present, the guard allows the request through.
 
@@ -712,7 +712,7 @@ The client calls this endpoint and passes the result to `AccessProvider` (Chapte
     <AccordionTrigger>How does NestJS action/resource inference work?</AccordionTrigger>
     <AccordionContent className="text-muted-foreground">
       When `@Authorize()` uses `infer: true` (the default), the guard reads the HTTP method
-      to determine the action (via `METHOD_ACTION_MAP`) and parses the controller route path
+      to determine the action (via `IAM_METHOD_ACTION_MAP`) and parses the controller route path
       for the resource type, taking the last non-parameter segment (ignoring `:id` style
       params). For `@Controller('posts')` with `@Delete(':id')`, the inferred action is
       `delete` and resource is `posts`.

--- a/apps/duck/content/docs/duck-iam/course/chapter-7.mdx
+++ b/apps/duck/content/docs/duck-iam/course/chapter-7.mdx
@@ -48,7 +48,7 @@ A `PermissionMap` is a key-value object generated on the server:
 
 ### PermissionKey Format
 
-Keys are colon-separated strings built by `buildPermissionKey()`:
+Keys are colon-separated strings built by `iamBuildPermissionKey()`:
 
 ```typescript
 type PermissionKey =
@@ -274,7 +274,7 @@ Works in any environment: server, client, tests, or Node.js scripts.
       createAccessState,
       Can,
       Cannot,
-      ACCESS_INJECTION_KEY,
+      IAM_ACCESS_INJECTION_KEY,
     } = createVueAccess({ ref, computed, inject, provide, defineComponent, h })
     ```
 
@@ -289,7 +289,7 @@ Works in any environment: server, client, tests, or Node.js scripts.
     | `createAccessState(perms)` | Function | Low-level reactive state factory |
     | `Can` | Component | Renders slot when permission granted |
     | `Cannot` | Component | Renders slot when permission denied |
-    | `ACCESS_INJECTION_KEY` | Symbol | For advanced provide/inject scenarios |
+    | `IAM_ACCESS_INJECTION_KEY` | Symbol | For advanced provide/inject scenarios |
   </Step>
 
   <Step>

--- a/apps/duck/content/docs/duck-iam/course/chapter-8.mdx
+++ b/apps/duck/content/docs/duck-iam/course/chapter-8.mdx
@@ -510,19 +510,19 @@ import * as tables from './schema'
 const adapter = new IamDrizzleAdapter({
   db,
   tables: {
-    policies: tables.accessPolicies,
-    roles: tables.accessRoles,
-    assignments: tables.accessAssignments,
-    attrs: tables.accessSubjectAttrs,
+    policies: tables.iamPolicies,
+    roles: tables.iamRoles,
+    assignments: tables.iamAssignments,
+    attrs: tables.iamSubjectAttrs,
   },
   ops: { eq, and },
 })
 ```
 
-#### DrizzleConfig Interface
+#### IamDrizzle.IConfig Interface
 
 ```typescript
-interface DrizzleConfig {
+interface IamDrizzle.IConfig {
   db: {
     select: () => { from: (table: unknown) => DrizzleQuery }
     insert: (table: unknown) => { values: (data: Record<string, unknown>) => DrizzleInsert }
@@ -554,7 +554,7 @@ interface DrizzleConfig {
 ```typescript title="src/schema.ts"
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core'
 
-export const accessPolicies = sqliteTable('access_policies', {
+export const iamPolicies = sqliteTable('access_policies', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),
   description: text('description'),
@@ -564,7 +564,7 @@ export const accessPolicies = sqliteTable('access_policies', {
   targets: text('targets'),              // JSON string or null
 })
 
-export const accessRoles = sqliteTable('access_roles', {
+export const iamRoles = sqliteTable('access_roles', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),
   description: text('description'),
@@ -574,7 +574,7 @@ export const accessRoles = sqliteTable('access_roles', {
   metadata: text('metadata'),
 })
 
-export const accessAssignments = sqliteTable('access_assignments', {
+export const iamAssignments = sqliteTable('access_assignments', {
   subjectId: text('subject_id').notNull(),
   roleId: text('role_id').notNull(),
   scope: text('scope'),
@@ -582,7 +582,7 @@ export const accessAssignments = sqliteTable('access_assignments', {
   pk: primaryKey(t.subjectId, t.roleId, t.scope),
 }))
 
-export const accessSubjectAttrs = sqliteTable('access_subject_attrs', {
+export const iamSubjectAttrs = sqliteTable('access_subject_attrs', {
   subjectId: text('subject_id').primaryKey(),
   data: text('data').notNull(),   // JSON string
 })
@@ -771,7 +771,7 @@ The engine uses four LRU caches to minimize adapter calls:
 The cache is a custom LRU (Least Recently Used) implementation backed by a `Map`:
 
 ```typescript
-class LRUCache<V> {
+class IamLRUCache<V> {
   private map = new Map<string, { value: V; expiresAt: number }>()
   private maxSize: number
   private ttl: number
@@ -1004,15 +1004,15 @@ const MAX_REGEX_LENGTH = 512
 const REGEX_CACHE_MAX = 256
 
 function getCachedRegex(pattern: string): RegExp | null {
-  const cached = regexCache.get(pattern)
+  const cached = iamRegexCache.get(pattern)
   if (cached) return cached
   try {
     const re = new RegExp(pattern)
-    if (regexCache.size >= REGEX_CACHE_MAX) {
-      const first = regexCache.keys().next().value
-      if (first !== undefined) regexCache.delete(first)
+    if (iamRegexCache.size >= REGEX_CACHE_MAX) {
+      const first = iamRegexCache.keys().next().value
+      if (first !== undefined) iamRegexCache.delete(first)
     }
-    regexCache.set(pattern, re)
+    iamRegexCache.set(pattern, re)
     return re
   } catch {
     return null   // invalid regex -> fail closed

--- a/apps/duck/content/docs/duck-iam/guides/production.mdx
+++ b/apps/duck/content/docs/duck-iam/guides/production.mdx
@@ -160,7 +160,7 @@ const engine = new IamEngine({
 - `onError` - adapter failures, condition tree throws. Page on rate.
 - `onPolicyError` - one rotten row in the adapter. Page on rate.
 - `onDeny` - audit log. Required for SOC2 / ISO 27001.
-- `onMetrics` - latency + outcome telemetry. Wire to `createMetricsAggregator()` (next section).
+- `onMetrics` - latency + outcome telemetry. Wire to `iamCreateMetricsAggregator()` (next section).
 - `afterEvaluate` - debug only; allocates a `Decision` even in production mode. Disable in prod.
 
 ---
@@ -221,12 +221,12 @@ Probe runs one `listPolicies` with the configured `adapterTimeoutMs`. Cheap enou
 
 ## Metrics aggregation
 
-Wire `createMetricsAggregator()` to `onMetrics` and expose its snapshot:
+Wire `iamCreateMetricsAggregator()` to `onMetrics` and expose its snapshot:
 
 ```ts
-import { createMetricsAggregator } from '@gentleduck/iam/observability/metrics'
+import { iamCreateMetricsAggregator } from '@gentleduck/iam/observability/metrics'
 
-const metrics = createMetricsAggregator({ sampleSize: 1000 })
+const metrics = iamCreateMetricsAggregator({ sampleSize: 1000 })
 const engine = new IamEngine({ adapter, hooks: { onMetrics: metrics.record } })
 
 app.get('/metrics', (_, res) => res.json(metrics.snapshot()))
@@ -258,7 +258,7 @@ Bench shows ~15x speedup on the first call vs cold.
 
 ## Shared cache flushing (multi-tenant)
 
-`flushSharedCaches()` wipes the process-wide compiled-regex cache
+`iamFlushSharedCaches()` wipes the process-wide compiled-regex cache
 (matches operator) and the dot-path segment cache. Both are module-globals
 shared across every Engine instance in the process. In multi-tenant
 deployments, a hostile tenant flooding distinct `matches` patterns or
@@ -267,7 +267,7 @@ influence. SEC-050.
 
 ```ts
 // Multi-tenant operators: flush every 5 minutes.
-setInterval(() => flushSharedCaches(), 5 * 60 * 1000)
+setInterval(() => iamFlushSharedCaches(), 5 * 60 * 1000)
 ```
 
 Cost: the next request from every tenant pays one regex-compile per
@@ -339,6 +339,6 @@ Before flipping production traffic on:
 - [ ] `/metrics` route returns aggregator snapshot
 - [ ] `engine.preload()` in startup
 - [ ] `engine.dispose()` in shutdown
-- [ ] `flushSharedCaches()` scheduled in multi-tenant deployments (SEC-050)
+- [ ] `iamFlushSharedCaches()` scheduled in multi-tenant deployments (SEC-050)
 - [ ] Admin routes mounted behind a real `authorize` callback (not a stub)
 - [ ] Policies bounded under `maxPolicies` (default `10_000`)

--- a/apps/duck/content/docs/duck-iam/guides/troubleshooting.mdx
+++ b/apps/duck/content/docs/duck-iam/guides/troubleshooting.mdx
@@ -79,7 +79,7 @@ a TS error.
 
 **Symptoms**: `validatePolicy()` returns `{ code: 'POLICY_LIMIT_EXCEEDED' }`.
 
-**Cause**: A single policy exceeds `POLICY_LIMITS` (number of rules,
+**Cause**: A single policy exceeds `IAM_POLICY_LIMITS` (number of rules,
 actions per rule, resources per rule). The defaults are generous (50
 rules, 100 actions, 100 resources). If you've hit them, the policy is
 likely a "god policy" that mixes too many domains - split it.

--- a/apps/duck/content/docs/duck-iam/integrations/adapters/drizzle.mdx
+++ b/apps/duck/content/docs/duck-iam/integrations/adapters/drizzle.mdx
@@ -26,10 +26,10 @@ Pick the entry that matches your database. All three define the same four tables
 
 ```typescript
 import {
-  accessPolicies,
-  accessRoles,
-  accessAssignments,
-  accessSubjectAttrs,
+  iamPolicies,
+  iamRoles,
+  iamAssignments,
+  iamSubjectAttrs,
 } from '@gentleduck/iam/adapters/drizzle/schema/pg'
 ```
 
@@ -43,10 +43,10 @@ import {
 
 ```typescript
 import {
-  accessPolicies,
-  accessRoles,
-  accessAssignments,
-  accessSubjectAttrs,
+  iamPolicies,
+  iamRoles,
+  iamAssignments,
+  iamSubjectAttrs,
 } from '@gentleduck/iam/adapters/drizzle/schema/mysql'
 ```
 
@@ -59,10 +59,10 @@ import {
 
 ```typescript
 import {
-  accessPolicies,
-  accessRoles,
-  accessAssignments,
-  accessSubjectAttrs,
+  iamPolicies,
+  iamRoles,
+  iamAssignments,
+  iamSubjectAttrs,
 } from '@gentleduck/iam/adapters/drizzle/schema/sqlite'
 ```
 
@@ -76,7 +76,7 @@ import {
 ## What each schema includes
 
 - Named constraints throughout: `pk_` primary key, `fk_` foreign key, `uq_` unique, `idx_` index, `ch_` check
-- FK cascade on `roleId` -> `accessRoles.id`
+- FK cascade on `roleId` -> `iamRoles.id`
 - Unique on `(subjectId, roleId, scope)` for idempotent assignments, with NULL scopes collapsed (`NULLS NOT DISTINCT` on PG, `COALESCE` on MySQL/SQLite)
 - Lookup index on `subjectId` plus a `roleId` index for FK deletes and reverse lookups
 - CHECK constraints: non-blank name/subject, `version >= 1`, valid algorithm
@@ -119,10 +119,10 @@ import { Pool } from 'pg'
 import { IamDrizzleAdapter } from '@gentleduck/iam/adapters/drizzle'
 import { IamEngine } from '@gentleduck/iam'
 import {
-  accessPolicies,
-  accessRoles,
-  accessAssignments,
-  accessSubjectAttrs,
+  iamPolicies,
+  iamRoles,
+  iamAssignments,
+  iamSubjectAttrs,
 } from '@gentleduck/iam/adapters/drizzle/schema/pg'
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL })
@@ -131,10 +131,10 @@ const db = drizzle(pool)
 const adapter = new IamDrizzleAdapter({
   db,
   tables: {
-    policies: accessPolicies,
-    roles: accessRoles,
-    assignments: accessAssignments,
-    attrs: accessSubjectAttrs,
+    policies: iamPolicies,
+    roles: iamRoles,
+    assignments: iamAssignments,
+    attrs: iamSubjectAttrs,
   },
   ops: { eq, and },
 })
@@ -174,7 +174,7 @@ The read path accepts both shapes, so switching modes is migration-safe. For SQL
 ```typescript
 const adapter = new IamDrizzleAdapter({
   db,
-  tables: { policies: accessPolicies, roles: accessRoles, assignments: accessAssignments, attrs: accessSubjectAttrs },
+  tables: { policies: iamPolicies, roles: iamRoles, assignments: iamAssignments, attrs: iamSubjectAttrs },
   ops: { eq, and },
   json: 'string', // SQLite stores JSON as TEXT
 })

--- a/apps/duck/content/docs/duck-iam/integrations/adapters/redis.mdx
+++ b/apps/duck/content/docs/duck-iam/integrations/adapters/redis.mdx
@@ -9,7 +9,7 @@ section: Integrations
 import { IamRedisAdapter } from '@gentleduck/iam/adapters/redis'
 ```
 
-Distributed key/value backend. Works with [`ioredis`](https://github.com/redis/ioredis), [`node-redis`](https://github.com/redis/node-redis) v4+, or any client matching the `RedisLike` interface.
+Distributed key/value backend. Works with [`ioredis`](https://github.com/redis/ioredis), [`node-redis`](https://github.com/redis/node-redis) v4+, or any client matching the `AuthRedisLike` interface.
 
 ```bash
 bun add ioredis
@@ -22,7 +22,7 @@ bun add redis
 ## When to use
 
 - **Multi-instance deploys** - share policy/role state across nodes
-- **Edge / serverless** - Upstash Redis, Cloudflare KV (behind a `RedisLike` shim), Vercel KV
+- **Edge / serverless** - Upstash Redis, Cloudflare KV (behind a `AuthRedisLike` shim), Vercel KV
 - **Pair with Engine LRU cache** - Redis = source of truth, in-process LRU = hot reads
 - **Cross-tenant SaaS** - `keyPrefix` isolates tenants in a shared Redis
 
@@ -90,13 +90,13 @@ Set semantics make `assignRole` idempotent - calling it twice with the same `(su
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `client` | `RedisLike` | -- | Any client implementing the minimal Redis surface |
+| `client` | `AuthRedisLike` | -- | Any client implementing the minimal Redis surface |
 | `keyPrefix` | `string` | `''` | Optional prefix to namespace duck-iam keys |
 
-### `RedisLike` interface
+### `AuthRedisLike` interface
 
 ```typescript
-interface RedisLike {
+interface AuthRedisLike {
   get(key: string): Promise<string | null>
   set(key: string, value: string): Promise<unknown>
   del(...keys: string[]): Promise<number>
@@ -180,4 +180,4 @@ const config: Redis.IConfig = {
 }
 ```
 
-Deprecated bare aliases (`RedisLike`, `RedisAdapterConfig`) remain for back-compat and will be removed in 3.0.
+Deprecated bare aliases (`AuthRedisLike`, `RedisAdapterConfig`) remain for back-compat and will be removed in 3.0.

--- a/apps/duck/content/docs/duck-iam/integrations/client/index.mdx
+++ b/apps/duck/content/docs/duck-iam/integrations/client/index.mdx
@@ -44,7 +44,7 @@ Client checks are **synchronous lookups** against the pre-computed map. No netwo
 | Vue | [client/vue](/duck-iam/integrations/client/vue) | `@gentleduck/iam/client/vue` |
 | Vanilla JS | [client/vanilla](/duck-iam/integrations/client/vanilla) | `@gentleduck/iam/client/vanilla` |
 
-Use the [PermissionMap reference](/duck-iam/integrations/client/permission-map) for the wire format, key encoding, and `buildPermissionKey()` helper.
+Use the [PermissionMap reference](/duck-iam/integrations/client/permission-map) for the wire format, key encoding, and `iamBuildPermissionKey()` helper.
 
 ---
 

--- a/apps/duck/content/docs/duck-iam/integrations/client/permission-map.mdx
+++ b/apps/duck/content/docs/duck-iam/integrations/client/permission-map.mdx
@@ -1,6 +1,6 @@
 ---
 title: PermissionMap reference
-description: Wire format, key encoding rules, and buildPermissionKey helper for the duck-iam client integrations.
+description: Wire format, key encoding rules, and iamBuildPermissionKey helper for the duck-iam client integrations.
 section: Integrations
 ---
 ## What is a PermissionMap?
@@ -42,23 +42,23 @@ The shape is determined by which fields you pass when generating the map (or cal
 
 ---
 
-## buildPermissionKey
+## iamBuildPermissionKey
 
 The same key builder powers every client integration:
 
 ```typescript
-import { buildPermissionKey } from '@gentleduck/iam'
+import { iamBuildPermissionKey } from '@gentleduck/iam'
 
-buildPermissionKey('delete', 'post')
+iamBuildPermissionKey('delete', 'post')
 // "delete:post"
 
-buildPermissionKey('update', 'post', 'post-42', 'org-1')
+iamBuildPermissionKey('update', 'post', 'post-42', 'org-1')
 // "org-1:update:post:post-42"
 ```
 
 Order: `(action, resource, resourceId?, scope?)`. The serialized key always reorders as `scope:action:resource:resourceId` so server and client agree.
 
-You rarely call `buildPermissionKey()` directly - the React, Vue, and vanilla clients call it internally. Reach for it when:
+You rarely call `iamBuildPermissionKey()` directly - the React, Vue, and vanilla clients call it internally. Reach for it when:
 
 - Writing tests that assert specific keys
 - Building custom permission map endpoints

--- a/apps/duck/content/docs/duck-iam/integrations/client/vue.mdx
+++ b/apps/duck/content/docs/duck-iam/integrations/client/vue.mdx
@@ -6,7 +6,7 @@ section: Integrations
 ## Install
 
 ```typescript
-import { createVueAccess, ACCESS_INJECTION_KEY } from '@gentleduck/iam/client/vue'
+import { createVueAccess, IAM_ACCESS_INJECTION_KEY } from '@gentleduck/iam/client/vue'
 ```
 
 Vue 3 is an optional peer dep. The factory accepts your reactive utilities (`ref`, `inject`, `provide`, `defineComponent`) to avoid a hard version dependency.
@@ -167,17 +167,17 @@ This is returned from `createVueAccess()` alongside the other exports. Combine i
 
 ---
 
-## ACCESS_INJECTION_KEY
+## IAM_ACCESS_INJECTION_KEY
 
-Exported `Symbol` used by `provideAccess`/`useAccess` internally. You can re-use it if you need to bypass the helpers and call `provide(ACCESS_INJECTION_KEY, state)` yourself - for example, when wiring duck-iam into a custom plugin pipeline.
+Exported `Symbol` used by `provideAccess`/`useAccess` internally. You can re-use it if you need to bypass the helpers and call `provide(IAM_ACCESS_INJECTION_KEY, state)` yourself - for example, when wiring duck-iam into a custom plugin pipeline.
 
 ```typescript
 import { provide } from 'vue'
-import { ACCESS_INJECTION_KEY } from '@gentleduck/iam/client/vue'
+import { IAM_ACCESS_INJECTION_KEY } from '@gentleduck/iam/client/vue'
 import { createAccessState } from '@/lib/access'
 
 const state = createAccessState(permissions)
-provide(ACCESS_INJECTION_KEY, state)
+provide(IAM_ACCESS_INJECTION_KEY, state)
 ```
 
 ---

--- a/apps/duck/content/docs/duck-iam/integrations/index.mdx
+++ b/apps/duck/content/docs/duck-iam/integrations/index.mdx
@@ -26,11 +26,11 @@ import { IamEngine } from '@gentleduck/iam/core'
 import { IamDrizzleAdapter } from '@gentleduck/iam/adapters/drizzle'
 import { adminRouter, guard } from '@gentleduck/iam/server/express'
 import { createIamRedisInvalidator } from '@gentleduck/iam/invalidators/redis'
-import { createMetricsAggregator } from '@gentleduck/iam/observability/metrics'
+import { iamCreateMetricsAggregator } from '@gentleduck/iam/observability/metrics'
 
 const adapter = new IamDrizzleAdapter(db, schema)
 const invalidator = createIamRedisInvalidator({ client: redis })
-const metrics = createMetricsAggregator()
+const metrics = iamCreateMetricsAggregator()
 
 const engine = new IamEngine({
   adapter,

--- a/apps/duck/content/docs/duck-iam/integrations/observability/metrics.mdx
+++ b/apps/duck/content/docs/duck-iam/integrations/observability/metrics.mdx
@@ -5,7 +5,7 @@ section: Integrations
 ---
 ## What it does
 
-`createMetricsAggregator` is a ring-buffer histogram over `IamEngineTypes.IMetricsEvent`. Wire its `.record` method to `hooks.onMetrics` and call `.snapshot()` on demand - a `/metrics` route, a Prometheus scrape, an OTel exporter, whatever your pipeline expects.
+`iamCreateMetricsAggregator` is a ring-buffer histogram over `IamEngineTypes.IMetricsEvent`. Wire its `.record` method to `hooks.onMetrics` and call `.snapshot()` on demand - a `/metrics` route, a Prometheus scrape, an OTel exporter, whatever your pipeline expects.
 
 No external dependencies, no allocations on the hot path beyond a `Float64Array` slot per recorded event.
 
@@ -14,7 +14,7 @@ No external dependencies, no allocations on the hot path beyond a `Float64Array`
 ## Install
 
 ```typescript
-import { createMetricsAggregator } from '@gentleduck/iam/observability/metrics'
+import { iamCreateMetricsAggregator } from '@gentleduck/iam/observability/metrics'
 ```
 
 ---
@@ -23,9 +23,9 @@ import { createMetricsAggregator } from '@gentleduck/iam/observability/metrics'
 
 ```typescript
 import { IamEngine } from '@gentleduck/iam'
-import { createMetricsAggregator } from '@gentleduck/iam/observability/metrics'
+import { iamCreateMetricsAggregator } from '@gentleduck/iam/observability/metrics'
 
-const metrics = createMetricsAggregator({ sampleSize: 1000 })
+const metrics = iamCreateMetricsAggregator({ sampleSize: 1000 })
 
 const engine = new IamEngine({
   adapter,
@@ -110,7 +110,7 @@ import { Counter, Histogram } from 'prom-client'
 const iamTotal = new Counter({ name: 'iam_evaluations_total', help: '...', labelNames: ['outcome'] })
 const iamLatency = new Histogram({ name: 'iam_evaluation_duration_ms', help: '...' })
 
-const metrics = createMetricsAggregator()
+const metrics = iamCreateMetricsAggregator()
 
 const engine = new IamEngine({
   adapter,
@@ -141,8 +141,8 @@ The aggregator is a *complement* to Prometheus, not a replacement - it gives you
 Want one aggregator for `allow`, another for `deny`? Wire both:
 
 ```typescript
-const allowMetrics = createMetricsAggregator()
-const denyMetrics = createMetricsAggregator()
+const allowMetrics = iamCreateMetricsAggregator()
+const denyMetrics = iamCreateMetricsAggregator()
 
 const engine = new IamEngine({
   adapter,
@@ -162,7 +162,7 @@ Same pattern works for per-resource or per-action breakdowns.
 
 All types live under the `Metrics` namespace at `@gentleduck/iam/observability/metrics`. Type-only - zero bundle cost.
 
-- `Metrics.IAggregator` - return shape of `createMetricsAggregator` (`record`, `snapshot`, `reset`).
+- `Metrics.IAggregator` - return shape of `iamCreateMetricsAggregator` (`record`, `snapshot`, `reset`).
 - `Metrics.ISnapshot` - shape returned by `.snapshot()` (`total`, `allow`, `deny`, `failOpen`, `p50`, `p95`, `p99`, `max`, `samples`).
 - `Metrics.IConfig` - constructor config (`sampleSize`).
 
@@ -170,7 +170,7 @@ All types live under the `Metrics` namespace at `@gentleduck/iam/observability/m
 import type { Metrics } from '@gentleduck/iam/observability/metrics'
 
 const config: Metrics.IConfig = { sampleSize: 1000 }
-const aggregator: Metrics.IAggregator = createMetricsAggregator(config)
+const aggregator: Metrics.IAggregator = iamCreateMetricsAggregator(config)
 const snap: Metrics.ISnapshot = aggregator.snapshot()
 ```
 

--- a/apps/duck/content/docs/duck-iam/integrations/server/express.mdx
+++ b/apps/duck/content/docs/duck-iam/integrations/server/express.mdx
@@ -19,14 +19,14 @@ Apply access control to every route under a path prefix.
 
 ```typescript
 import { accessMiddleware } from '@gentleduck/iam/server/express'
-import { METHOD_ACTION_MAP } from '@gentleduck/iam/server/generic'
+import { IAM_METHOD_ACTION_MAP } from '@gentleduck/iam/server/generic'
 
 const middleware = accessMiddleware(engine, {
   // Extract user ID from your auth layer (passport, jwt, etc.)
   getUserId: (req) => req.user?.id,
 
-  // Map HTTP method to action (defaults to METHOD_ACTION_MAP)
-  getAction: (req) => METHOD_ACTION_MAP[req.method],
+  // Map HTTP method to action (defaults to IAM_METHOD_ACTION_MAP)
+  getAction: (req) => IAM_METHOD_ACTION_MAP[req.method],
 
   // Infer resource from the URL path
   getResource: (req) => {

--- a/apps/duck/content/docs/duck-iam/integrations/server/generic.mdx
+++ b/apps/duck/content/docs/duck-iam/integrations/server/generic.mdx
@@ -1,15 +1,15 @@
 ---
 title: generic helpers
-description: Framework-agnostic helpers - METHOD_ACTION_MAP, createSubjectCan, extractEnvironment, generatePermissionMap. Use across runtimes or for custom integrations.
+description: Framework-agnostic helpers - IAM_METHOD_ACTION_MAP, createSubjectCan, extractEnvironment, generatePermissionMap. Use across runtimes or for custom integrations.
 section: Integrations
 ---
 ## Install
 
 ```ts
 import {
-  METHOD_ACTION_MAP,
+  IAM_METHOD_ACTION_MAP,
   createSubjectCan,
-  defaultCsrfCheck,
+  iamDefaultCsrfCheck,
   extractEnvironment,
   generatePermissionMap,
 } from '@gentleduck/iam/server/generic'
@@ -26,8 +26,8 @@ Use the generic helpers when the framework wrappers are too opinionated, or when
 | `generatePermissionMap` | `(engine, subjectId, checks, environment?)` | Wraps `engine.permissions()` for server-to-client hydration |
 | `createSubjectCan` | `(engine, subjectId, environment?)` | Returns a subject-bound `can(action, resource, resourceId?, scope?)` |
 | `extractEnvironment` | `(req)` | Builds the default `{ ip, userAgent, timestamp }` from common request shapes |
-| `defaultCsrfCheck` | `(req) -> boolean` | Built-in `Sec-Fetch-Site` predicate the admin routers use by default (SEC-103) |
-| `METHOD_ACTION_MAP` | `Record<string, string>` | Read-only CRUD map (GET -> read, POST -> create, etc.) used by every built-in integration |
+| `iamDefaultCsrfCheck` | `(req) -> boolean` | Built-in `Sec-Fetch-Site` predicate the admin routers use by default (SEC-103) |
+| `IAM_METHOD_ACTION_MAP` | `Record<string, string>` | Read-only CRUD map (GET -> read, POST -> create, etc.) used by every built-in integration |
 
 ---
 
@@ -92,18 +92,18 @@ Override anywhere a `getEnvironment` option is exposed by passing your own extra
 
 ## Default CSRF predicate
 
-`defaultCsrfCheck` is the `Sec-Fetch-Site` predicate every admin router uses
+`iamDefaultCsrfCheck` is the `Sec-Fetch-Site` predicate every admin router uses
 by default (SEC-103 / CAVEAT-2). It handles all four request shapes
 (Express/Nest record headers, fetch-API `Headers.get`, Hono `c.req.header`).
 Returns `true` when the request is allowed, `false` when it must be rejected.
 
 ```ts
-import { defaultCsrfCheck } from '@gentleduck/iam/server/generic'
+import { iamDefaultCsrfCheck } from '@gentleduck/iam/server/generic'
 
 // Compose with your own check - accept default behaviour AND require Origin.
 const allow = new Set(['https://admin.example.com'])
 const csrfCheck = (req: Request) =>
-  defaultCsrfCheck(req) && allow.has(req.headers.get('origin') ?? '')
+  iamDefaultCsrfCheck(req) && allow.has(req.headers.get('origin') ?? '')
 ```
 
 `Sec-Fetch-Site` is populated by every modern browser; non-browser callers

--- a/apps/duck/content/docs/duck-iam/integrations/server/index.mdx
+++ b/apps/duck/content/docs/duck-iam/integrations/server/index.mdx
@@ -49,7 +49,7 @@ All five share the same building blocks: identity extraction, action mapping, re
 The default method-to-action map shared by every integration:
 
 ```typescript
-const METHOD_ACTION_MAP = {
+const IAM_METHOD_ACTION_MAP = {
   GET: 'read',
   HEAD: 'read',
   OPTIONS: 'read',
@@ -93,7 +93,7 @@ const middleware = accessMiddleware(engine, {
     if (req.method === 'POST' && req.path.endsWith('/publish')) {
       return 'publish'
     }
-    return METHOD_ACTION_MAP[req.method] ?? 'read'
+    return IAM_METHOD_ACTION_MAP[req.method] ?? 'read'
   },
 })
 ```

--- a/apps/duck/content/docs/duck-iam/integrations/server/nest.mdx
+++ b/apps/duck/content/docs/duck-iam/integrations/server/nest.mdx
@@ -11,8 +11,8 @@ import {
   Authorize,
   createTypedAuthorize,
   createEngineProvider,
-  ACCESS_ENGINE_TOKEN,
-  ACCESS_METADATA_KEY,
+  IAM_ACCESS_ENGINE_TOKEN,
+  IAM_ACCESS_METADATA_KEY,
 } from '@gentleduck/iam/server/nest'
 ```
 
@@ -116,7 +116,7 @@ import { Module } from '@nestjs/common'
 import { APP_GUARD } from '@nestjs/core'
 import {
   createEngineProvider,
-  ACCESS_ENGINE_TOKEN,
+  IAM_ACCESS_ENGINE_TOKEN,
   nestAccessGuard,
 } from '@gentleduck/iam/server/nest'
 
@@ -126,7 +126,7 @@ import {
     {
       provide: APP_GUARD,
       useFactory: (engine) => ({ canActivate: nestAccessGuard(engine) }),
-      inject: [ACCESS_ENGINE_TOKEN],
+      inject: [IAM_ACCESS_ENGINE_TOKEN],
     },
   ],
 })
@@ -161,8 +161,8 @@ The engine factory can be async - return a `Promise<IamEngine>` to support adapt
 
 | Token | Type | Purpose |
 | --- | --- | --- |
-| `ACCESS_ENGINE_TOKEN` | `string` (`'ACCESS_ENGINE'`) | DI token for the engine |
-| `ACCESS_METADATA_KEY` | `string` (`'duck-iam:authorize'`) | Reflect metadata key for the decorator |
+| `IAM_ACCESS_ENGINE_TOKEN` | `string` (`'ACCESS_ENGINE'`) | DI token for the engine |
+| `IAM_ACCESS_METADATA_KEY` | `string` (`'duck-iam:authorize'`) | Reflect metadata key for the decorator |
 
 ---
 
@@ -172,13 +172,13 @@ NestJS routes via controllers, so duck-iam ships gated admin *operations* (not a
 
 ```typescript
 import { Controller, Get, Put, Post, Delete, Inject, Req, Body, Param } from '@nestjs/common'
-import { ACCESS_ENGINE_TOKEN, createAdminOperations } from '@gentleduck/iam/server/nest'
+import { IAM_ACCESS_ENGINE_TOKEN, createAdminOperations } from '@gentleduck/iam/server/nest'
 
 @Controller('admin')
 export class IamAdminController {
   private readonly h
 
-  constructor(@Inject(ACCESS_ENGINE_TOKEN) engine) {
+  constructor(@Inject(IAM_ACCESS_ENGINE_TOKEN) engine) {
     this.h = createAdminOperations(engine, {
       authorize: (req) => req.user?.role === 'platform-admin',
     })

--- a/apps/duck/content/docs/duck-iam/introduction.mdx
+++ b/apps/duck/content/docs/duck-iam/introduction.mdx
@@ -47,8 +47,8 @@ are converted into policies internally, so one condition engine handles everythi
 | Server + client integrations | Express, Hono, Nest, Next middleware; React + Vue + vanilla clients. Each module ships its own typed namespace (`Express.IOptions`, `ReactClient.IContextValue`, ...). |
 | Evaluation hooks | `beforeEvaluate`, `afterEvaluate`, `onDeny`, `onError`, `onPolicyError`, `onMetrics` - observe / transform every decision. `onMetrics` is primitive-only and fires in both modes. |
 | Dev/Prod mode | Development returns rich `AccessControl.IDecision` objects + `explain()`; production returns plain `boolean` with zero allocation. See [benchmarks](/duck-iam/benchmarks) and the [production guide](/duck-iam/guides/production). |
-| Explain / debug | `engine.explain()` returns `IamExplain.IResult` with per-policy, per-rule, per-condition traces. Dev mode only. |
-| Validation + limits | `validateRoles()` and `validatePolicy()` emit `IamValidate.IIssue` with closed-set codes. `POLICY_LIMITS` caps rule / action / resource counts; `MAX_INHERITANCE_DEPTH` caps role chains. |
+| Explain / debug | `engine.explain()` returns `Explain.IResult` with per-policy, per-rule, per-condition traces. Dev mode only. |
+| Validation + limits | `validateRoles()` and `validatePolicy()` emit `IamValidate.IIssue` with closed-set codes. `IAM_POLICY_LIMITS` caps rule / action / resource counts; `MAX_INHERITANCE_DEPTH` caps role chains. |
 | Operability surface | `engine.preload()`, `engine.healthCheck()`, `engine.stats.get()`, `engine.admin.export() / import()` snapshots, `IConfig.invalidator` for cross-instance cache coherence, adapter timeouts, fail-open opt-in. |
 
 ## Architecture Overview

--- a/apps/duck/content/docs/duck-iam/types.mdx
+++ b/apps/duck/content/docs/duck-iam/types.mdx
@@ -71,7 +71,7 @@ The class `IamEngine` lives next to the `IamEngineTypes` namespace - same name a
 
 Three reasons.
 
-**1. Avoid name collisions across modules.** `IResult` exists in both `Validate` and `Explain`. Without namespaces, one of them needs a longer name. With namespaces, both stay short and the context is explicit at the call site (`IamValidate.IResult` vs `IamExplain.IResult`).
+**1. Avoid name collisions across modules.** `IResult` exists in both `Validate` and `Explain`. Without namespaces, one of them needs a longer name. With namespaces, both stay short and the context is explicit at the call site (`IamValidate.IResult` vs `Explain.IResult`).
 
 **2. One import per module.** Instead of:
 

--- a/skills/duck-iam/SKILL.md
+++ b/skills/duck-iam/SKILL.md
@@ -37,12 +37,12 @@ Modern ABAC/RBAC access control engine. Framework-agnostic core with integration
 
 ### 1. Define Your Access Schema
 
-Use `createAccessConfig` with `as const` arrays for full type safety. Every builder method constrains actions, resources, roles, and scopes at compile time.
+Use `createIam` with `as const` arrays for full type safety. Every builder method constrains actions, resources, roles, and scopes at compile time.
 
 ```ts
-import { createAccessConfig } from '@gentleduck/iam'
+import { createIam } from '@gentleduck/iam'
 
-const access = createAccessConfig({
+const access = createIam({
   actions: ['create', 'read', 'update', 'delete', 'publish'] as const,
   resources: ['post', 'comment', 'user'] as const,
   roles: ['viewer', 'editor', 'admin'] as const,
@@ -316,12 +316,12 @@ if (can('delete', 'post')) { /* show delete button */ }
 Use `MemoryAdapter` for unit tests. Seed it with roles, policies, and assignments, then assert with `engine.can()` or `engine.check()`:
 
 ```ts
-import { createAccessConfig } from '@gentleduck/iam'
+import { createIam } from '@gentleduck/iam'
 import { MemoryAdapter } from '@gentleduck/iam/adapters/memory'
 import { describe, expect, it } from 'vitest'
 
 describe('authorization', () => {
-  const access = createAccessConfig({
+  const access = createIam({
     actions: ['read', 'delete'] as const,
     resources: ['post'] as const,
     roles: ['viewer', 'admin'] as const,
@@ -355,7 +355,7 @@ Use `engine.explain()` to debug failing assertions -- it returns the full evalua
 
 ## Coding Conventions
 
-- Use `createAccessConfig` for type-safe builders. Use standalone `defineRole`/`defineRule`/`policy`/`when` only for untyped or dynamic scenarios.
+- Use `createIam` for type-safe builders. Use standalone `defineRole`/`defineRule`/`policy`/`when` only for untyped or dynamic scenarios.
 - Always call `.build()` to finalize builders -- they return plain data objects.
 - Roles produce RBAC permissions; policies produce ABAC rules. The engine combines both.
 - A deny from any policy is final when using `deny-overrides`.


### PR DESCRIPTION
## Summary

- Rename `createAccessConfig` → `createIam` throughout all duck-iam docs
- Update type references: `IamExplain.IResult` → `Explain.IResult`, `POLICY_LIMITS` → `IAM_POLICY_LIMITS`
- Sync duck-auth page and IAM sidebar with renamed exports
- Update duck-iam skill reference doc

## Test plan

- [ ] Verify duck-iam docs pages render correctly
- [ ] Verify sidebar links resolve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Duck Auth and Duck IAM docs to reflect new naming across guides, examples, and reference pages.
  * Reworked setup, client, server, channel, compliance, and adapter snippets to match the latest public API names.
  * Clarified production, security, testing, and multi-tenancy guidance with the renamed helpers and components.
  * Updated sidebar and changelog references so navigation and examples stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->