### PR TITLE
chore: version bump for arrow overlay components

### DIFF
--- a/.changeset/feat-arrow-overlay-components.md
+++ b/.changeset/feat-arrow-overlay-components.md
@@ -1,5 +1,0 @@
----
-"@gentleduck/registry-ui": minor
----
-
-Add styled arrow components for overlay components: `TooltipArrow`, `PopoverArrow`, `HoverCardArrow`, and `DropdownMenuArrow`. Arrows use a bezier curve SVG shape that seamlessly joins the content border, with border stroke on curved sides only via a two-path technique. Border color is customizable via `--tooltip-border-color`, `--popover-border-color`, `--hover-card-border-color`, and `--dropdown-menu-border-color` CSS custom properties on the respective content elements. Also fixes `overflow-hidden` removal from content containers so arrows are not clipped, adds `relative` positioning for correct arrow animation, and restructures `DropdownMenuContent` with an inner scrollable wrapper to decouple overflow from the arrow's containing block.

--- a/.changeset/fix-arrow-primitive-bezier-path.md
+++ b/.changeset/fix-arrow-primitive-bezier-path.md
@@ -1,5 +1,0 @@
----
-"@gentleduck/primitives": patch
----
-
-Fix arrow base component to use smooth bezier curve path instead of polygon. Correct `TooltipArrow` and `PopoverArrow` to use `PopperArrow` primitive instead of `PopperAnchor` (was rendering invisible). Fix `asChild` propagation to `Primitive.svg` that caused SVG to become a Slot and eject children.

--- a/packages/duck-primitives/CHANGELOG.md
+++ b/packages/duck-primitives/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gentleduck/primitives
 
+## 0.3.1
+
+### Patch Changes
+
+- a157bae: Fix arrow base component to use smooth bezier curve path instead of polygon. Correct `TooltipArrow` and `PopoverArrow` to use `PopperArrow` primitive instead of `PopperAnchor` (was rendering invisible). Fix `asChild` propagation to `Primitive.svg` that caused SVG to become a Slot and eject children.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/duck-primitives/package.json
+++ b/packages/duck-primitives/package.json
@@ -86,7 +86,7 @@
   },
   "types": "./dist/index.d.ts",
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "dependencies": {
     "@floating-ui/react-dom": "^2.1.7",
     "@gentleduck/calendar": "^0.4.0",

--- a/packages/registry-examples/CHANGELOG.md
+++ b/packages/registry-examples/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @gentleduck/registry-examples
 
+## 0.2.13
+
+### Patch Changes
+
+- Updated dependencies [a157bae]
+  - @gentleduck/primitives@0.3.1
+
 ## 0.2.12
 
 ### Patch Changes

--- a/packages/registry-examples/package.json
+++ b/packages/registry-examples/package.json
@@ -58,5 +58,5 @@
     "check-types": "tsc -p tsconfig.json --noEmit --pretty false --skipLibCheck"
   },
   "type": "module",
-  "version": "0.2.12"
+  "version": "0.2.13"
 }

--- a/packages/registry-internals/CHANGELOG.md
+++ b/packages/registry-internals/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @gentleduck/registry-ui
 
+## 0.2.16
+
+### Patch Changes
+
+- Updated dependencies [a157bae]
+  - @gentleduck/primitives@0.3.1
+
 ## 0.2.15
 
 ### Patch Changes

--- a/packages/registry-internals/package.json
+++ b/packages/registry-internals/package.json
@@ -57,5 +57,5 @@
     "check-types": "tsc -p tsconfig.json --noEmit --pretty false --skipLibCheck"
   },
   "type": "module",
-  "version": "0.2.15"
+  "version": "0.2.16"
 }

--- a/packages/registry-ui/CHANGELOG.md
+++ b/packages/registry-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gentleduck/registry-ui
 
+## 0.6.0
+
+### Minor Changes
+
+- a157bae: Add styled arrow components for overlay components: `TooltipArrow`, `PopoverArrow`, `HoverCardArrow`, and `DropdownMenuArrow`. Arrows use a bezier curve SVG shape that seamlessly joins the content border, with border stroke on curved sides only via a two-path technique. Border color is customizable via `--tooltip-border-color`, `--popover-border-color`, `--hover-card-border-color`, and `--dropdown-menu-border-color` CSS custom properties on the respective content elements. Also fixes `overflow-hidden` removal from content containers so arrows are not clipped, adds `relative` positioning for correct arrow animation, and restructures `DropdownMenuContent` with an inner scrollable wrapper to decouple overflow from the arrow's containing block.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/registry-ui/package.json
+++ b/packages/registry-ui/package.json
@@ -65,7 +65,7 @@
   },
   "type": "module",
   "sideEffects": false,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Styled Tailwind components for Duck UI.",
   "keywords": [
     "gentleduck",


### PR DESCRIPTION
## Summary

Version bump after arrow overlay component feature.

| Package | Before | After | Type |
|---|---|---|---|
| `@gentleduck/primitives` | 0.3.0 | 0.3.1 | patch |
| `@gentleduck/registry-ui` | 0.5.0 | 0.6.0 | minor |

Changesets consumed. Dependents (`registry-examples`, `registry-internals`) bumped automatically.