### PR TITLE
fix(registry-ui): fix PopoverArrow type to not leak internal Scope

### DIFF
--- a/packages/registry-ui/src/popover/popover.tsx
+++ b/packages/registry-ui/src/popover/popover.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@gentleduck/libs/cn'
 import * as PopoverPrimitive from '@gentleduck/primitives/popover'
+import type { IPopover } from '@gentleduck/primitives/popover'
 import * as React from 'react'
 
 const Popover = PopoverPrimitive.Root
@@ -39,10 +40,8 @@ const PopoverContent = React.forwardRef<
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-const PopoverArrow = React.forwardRef<
-  React.ComponentRef<typeof PopoverPrimitive.Arrow>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Arrow>
->(({ className, style, ...props }, ref) => (
+const PopoverArrow = React.forwardRef<SVGSVGElement, IPopover.IArrowProps>(
+  ({ className, style, ...props }, ref) => (
   <PopoverPrimitive.Arrow
     ref={ref}
     asChild


### PR DESCRIPTION
## Summary

Fixes failing `Release` workflow CI on master.

`PopoverArrow` was typed as `React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Arrow>`, which expanded to include `__scopePopover?: Scope` — an internal type from `create-context-CKMcRGBM` in the primitives dist that can't be named in declarations.

Fix: use `IPopover.IArrowProps` (exported from the primitives) directly with `SVGSVGElement` ref, bypassing the scope-carrying component type entirely.

**Error:**
```
TS2883: The inferred type of 'PopoverArrow' cannot be named without a reference to 'Scope' from '.../create-context-CKMcRGBM'. This is likely not portable. A type annotation is necessary.
```