### PR TITLE
fix(registry-ui): fix biome errors in PopoverArrow

### DIFF
--- a/packages/registry-ui/src/popover/popover.tsx
+++ b/packages/registry-ui/src/popover/popover.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { cn } from '@gentleduck/libs/cn'
-import * as PopoverPrimitive from '@gentleduck/primitives/popover'
 import type { IPopover } from '@gentleduck/primitives/popover'
+import * as PopoverPrimitive from '@gentleduck/primitives/popover'
 import * as React from 'react'
 
 const Popover = PopoverPrimitive.Root
@@ -40,8 +40,7 @@ const PopoverContent = React.forwardRef<
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-const PopoverArrow = React.forwardRef<SVGSVGElement, IPopover.IArrowProps>(
-  ({ className, style, ...props }, ref) => (
+const PopoverArrow = React.forwardRef<SVGSVGElement, IPopover.IArrowProps>(({ className, style, ...props }, ref) => (
   <PopoverPrimitive.Arrow
     ref={ref}
     asChild


### PR DESCRIPTION
## Summary

Fixes the Release workflow "Lint and check" step failure on master.

Two biome errors in `packages/registry-ui/src/popover/popover.tsx` introduced by the PopoverArrow type fix:

1. **`assist/source/organizeImports`** — `import type { IPopover }` placed after the value import `import * as PopoverPrimitive`. Fixed: moved type import first.
2. **Formatter** — `React.forwardRef<...>(` followed by params on a new line. Fixed: collapsed to one line.

These are fixable errors (biome exits 1 without `--write`). The pre-commit hook used `--write` so they were silently fixed locally but caused CI to fail.